### PR TITLE
Enable CGO for sqlite support in docker images

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -13,7 +13,7 @@ LINKFLAGS="-X github.com/k3s-io/kine.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Kine
-CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/kine
+go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/kine
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/kine-darwin
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/kine-windows


### PR DESCRIPTION
Disabling CGO (and sqlite support along with it) wasn't intentional. The build script was copy-pasted from go-skel as per https://github.com/k3s-io/kine/issues/26#issuecomment-586618919 and https://github.com/k3s-io/kine/pull/42.

Fixes #68