### PR TITLE
Explicitly use ascii charset for the name column 

### DIFF
--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -24,7 +24,7 @@ var (
 		`CREATE TABLE IF NOT EXISTS kine
 			(
 				id INTEGER AUTO_INCREMENT,
-				name VARCHAR(630),
+				name VARCHAR(630) CHARACTER SET ascii,
 				created INTEGER,
 				deleted INTEGER,
 				create_revision INTEGER,


### PR DESCRIPTION
> MySQL [xxx]> CREATE UNIQUE INDEX kine_name_prev_revision_uindex ON kine (name, prev_revision);
ERROR 1071 (42000): Specified key was too long; max key length is 767 bytes

creating index will failing on mysql prior to 5.6 version, explicitly using ascii charset will workaround the failure

https://stackoverflow.com/a/1814594