### PR TITLE
remove duplicate KeysOnly check

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,10 +60,6 @@ func (k *KVServerBridge) Range(ctx context.Context, r *etcdserverpb.RangeRequest
 		return nil, unsupported("serializable")
 	}
 
-	if r.KeysOnly {
-		return nil, unsupported("keysOnly")
-	}
-
 	if r.MinModRevision != 0 {
 		return nil, unsupported("minModRevision")
 	}


### PR DESCRIPTION
nit: removes a duplicate KeysOnly check in Range request handler.