### PR TITLE
Add support for TLS on dqlite

### DIFF
--- a/pkg/drivers/dqlite/no_dqlite.go
+++ b/pkg/drivers/dqlite/no_dqlite.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/k3s-io/kine/pkg/drivers/generic"
 	"github.com/k3s-io/kine/pkg/server"
+	"github.com/k3s-io/kine/pkg/tls"
 )
 
-func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
 	return nil, errors.New(`this binary is built without dqlite support, compile with "-tags dqlite"`)
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -128,7 +128,7 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 		leaderElect = false
 		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
+		backend, err = dqlite.New(ctx, dsn, cfg.Config, cfg.ConnectionPoolConfig)
 	case PostgresBackend:
 		backend, err = pgsql.New(ctx, dsn, cfg.Config, cfg.ConnectionPoolConfig)
 	case MySQLBackend:


### PR DESCRIPTION
This PR adds simple TLS for dqlite. A certs pair needs to be provided during the creation of the dqlite driver.