### PR TITLE
Feat: automatically log slow sql executions

### DIFF
--- a/pkg/drivers/generic/tx.go
+++ b/pkg/drivers/generic/tx.go
@@ -95,15 +95,21 @@ func (t *Tx) CurrentRevision(ctx context.Context) (int64, error) {
 
 func (t *Tx) query(ctx context.Context, sql string, args ...interface{}) (*sql.Rows, error) {
 	logrus.Tracef("TX QUERY %v : %s", args, Stripped(sql))
+	trace := NewTrace()
+	defer trace.LogSlowSQL(Stripped(sql), args)
 	return t.x.QueryContext(ctx, sql, args...)
 }
 
 func (t *Tx) queryRow(ctx context.Context, sql string, args ...interface{}) *sql.Row {
 	logrus.Tracef("TX QUERY ROW %v : %s", args, Stripped(sql))
+	trace := NewTrace()
+	defer trace.LogSlowSQL(Stripped(sql), args)
 	return t.x.QueryRowContext(ctx, sql, args...)
 }
 
 func (t *Tx) execute(ctx context.Context, sql string, args ...interface{}) (result sql.Result, err error) {
 	logrus.Tracef("TX EXEC %v : %s", args, Stripped(sql))
+	trace := NewTrace()
+	defer trace.LogSlowSQL(Stripped(sql), args)
 	return t.x.ExecContext(ctx, sql, args...)
 }

--- a/pkg/drivers/generic/util.go
+++ b/pkg/drivers/generic/util.go
@@ -1,0 +1,26 @@
+package generic
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	slowSQLThreshold = time.Second
+)
+
+type Trace struct {
+	startTime time.Time
+}
+
+func NewTrace() *Trace {
+	return &Trace{startTime: time.Now()}
+}
+
+func (t *Trace) LogSlowSQL(sql Stripped, args ...interface{}) {
+	totalTime := time.Since(t.startTime)
+	if totalTime >= slowSQLThreshold {
+		logrus.Infof("Slow SQL (started: %v) (total time: %v): %s : %v", t.startTime, totalTime, sql, args)
+	}
+}


### PR DESCRIPTION
This PR adds feature to automatically log slow sql.

It's common that sometimes network or database problems occur in production which cause slow sql executions and lead to apiserver errors. It would be handy to automatically log some sql execution details when we meet a slow sql (only log slow sqls not to make the INFO log too verbose) for troubleshooting afterwards. It's also helpful for detecting real slow sql problems in real production use cases.