### PR TITLE
WIP: Fix prev_revision NULL

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,42 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k3s-io/kine/pkg/endpoint"
+)
+
+var (
+	config = endpoint.ETCDConfig{Endpoints: []string{"localhost:2379"}}
+)
+
+func TestList(t *testing.T) {
+	c, err := New(config)
+	if err != nil {
+		t.Errorf("Unable to create new client: %v", err)
+	}
+
+	_, err = c.List(context.TODO(), "/bootstrap", 0)
+	if err != nil {
+		t.Errorf("Failed to list /bootstrap: %v", err)
+	}
+}
+
+func TestCreateAndList(t *testing.T) {
+	c, err := New(config)
+	if err != nil {
+		t.Errorf("Unable to create new client: %v", err)
+	}
+
+	err = c.Create(context.TODO(), "/bootstrap/test", []byte("test"))
+
+	values, err := c.List(context.TODO(), "/bootstrap", 0)
+	if err != nil {
+		t.Errorf("Failed to list /bootstrap: %v", err)
+	}
+
+	for _, v := range values {
+		t.Logf("Got value: %s=%s", v.Key, v.Data)
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -85,25 +85,24 @@ func TestCreateAndListPrefix(t *testing.T) {
 	}
 }
 
-func TestDeleteAndListPrefix(t *testing.T) {
+func TestListAndDeletePrefix(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
-
-	err := testClient.Delete(ctx, "/test/x")
-	if err != nil {
-		t.Fatalf("Failed to delete '/test/x': %v", err)
-	}
 
 	values, err := testClient.List(ctx, "/test", 0)
 	if err != nil {
 		t.Fatalf("Failed to list '/test': %v", err)
 	}
 
-	if len(values) != 1 {
-		t.Fatal("Expected 0 values in list response")
+	if len(values) == 0 {
+		t.Fatal("Expected >0 values in list response")
 	}
 
 	for _, v := range values {
-		t.Logf("Got value: %s=%s", v.Key, v.Data)
+		t.Logf("Deleting value: %s=%s rev=%d", v.Key, v.Data, v.Modified)
+		err := testClient.Delete(ctx, string(v.Key), v.Modified)
+		if err != nil {
+			t.Errorf("Failed to delete '%s': %v", v.Key, err)
+		}
 	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -5,8 +5,13 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/k3s-io/kine/pkg/endpoint"
+)
+
+const (
+	testTimeout = 1 * time.Second
 )
 
 func getClient(t *testing.T) (Client, error) {
@@ -28,8 +33,12 @@ func TestList(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new client: %v", err)
 	}
+	defer c.Close()
 
-	values, err := c.List(context.TODO(), "/bootstrap", 0)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	values, err := c.List(ctx, "/bootstrap", 0)
 	if err != nil {
 		t.Errorf("Failed to list /bootstrap: %v", err)
 	}
@@ -43,10 +52,17 @@ func TestCreateAndList(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unable to create new client: %v", err)
 	}
+	defer c.Close()
 
-	err = c.Create(context.TODO(), "/bootstrap/test", []byte("test"))
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
 
-	values, err := c.List(context.TODO(), "/bootstrap", 0)
+	err = c.Create(ctx, "/bootstrap/test", []byte("test"))
+	if err != nil {
+		t.Errorf("Failed to create /bootstrap/test: %v", err)
+	}
+
+	values, err := c.List(ctx, "/bootstrap", 0)
 	if err != nil {
 		t.Errorf("Failed to list /bootstrap: %v", err)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,29 +2,44 @@ package client
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/k3s-io/kine/pkg/endpoint"
 )
 
-var (
-	config = endpoint.ETCDConfig{Endpoints: []string{"localhost:2379"}}
-)
+func getClient(t *testing.T) (Client, error) {
+	e := endpoint.ETCDConfig{Endpoints: []string{"localhost:2379"}}
+	if str := os.Getenv("K3S_DATASTORE_ENDPOINT"); str != "" {
+		// Strip off the scheme, if present
+		parts := strings.SplitN(str, "://", 2)
+		if len(parts) > 1 {
+			str = parts[1]
+		}
+		e.Endpoints = strings.Split(str, ",")
+	}
+	t.Logf("Connecting to etcd at %v", e.Endpoints)
+	return New(e)
+}
 
 func TestList(t *testing.T) {
-	c, err := New(config)
+	c, err := getClient(t)
 	if err != nil {
 		t.Errorf("Unable to create new client: %v", err)
 	}
 
-	_, err = c.List(context.TODO(), "/bootstrap", 0)
+	values, err := c.List(context.TODO(), "/bootstrap", 0)
 	if err != nil {
 		t.Errorf("Failed to list /bootstrap: %v", err)
+	}
+	if len(values) != 0 {
+		t.Error("Expected 0 values in list response")
 	}
 }
 
 func TestCreateAndList(t *testing.T) {
-	c, err := New(config)
+	c, err := getClient(t)
 	if err != nil {
 		t.Errorf("Unable to create new client: %v", err)
 	}
@@ -34,6 +49,10 @@ func TestCreateAndList(t *testing.T) {
 	values, err := c.List(context.TODO(), "/bootstrap", 0)
 	if err != nil {
 		t.Errorf("Failed to list /bootstrap: %v", err)
+	}
+
+	if len(values) != 1 {
+		t.Errorf("Expected 1 value in list response")
 	}
 
 	for _, v := range values {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -84,3 +84,26 @@ func TestCreateAndListPrefix(t *testing.T) {
 		t.Logf("Got value: %s=%s", v.Key, v.Data)
 	}
 }
+
+func TestDeleteAndListPrefix(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	err := testClient.Delete(ctx, "/test/x")
+	if err != nil {
+		t.Fatalf("Failed to delete '/test/x': %v", err)
+	}
+
+	values, err := testClient.List(ctx, "/test", 0)
+	if err != nil {
+		t.Fatalf("Failed to list '/test': %v", err)
+	}
+
+	if len(values) != 1 {
+		t.Fatal("Expected 0 values in list response")
+	}
+
+	for _, v := range values {
+		t.Logf("Got value: %s=%s", v.Key, v.Data)
+	}
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -27,44 +27,57 @@ func getClient(t *testing.T) (Client, error) {
 	return New(e)
 }
 
-func TestGetCliient(t *testing.T) {
+func TestGetClient(t *testing.T) {
 	c, err := getClient(t)
 	if err != nil {
-		t.Errorf("Unable to create new client: %v", err)
+		t.Fatalf("Unable to create new client: %v", err)
 		return
 	}
 	testClient = c
 }
 
-func TestList(t *testing.T) {
+func TestListAll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	values, err := testClient.List(ctx, "", 0)
+	if err != nil {
+		t.Fatalf("Failed to list '': %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("Expected 0 values in list response")
+	}
+}
+
+func TestListPrefix(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	values, err := testClient.List(ctx, "/test", 0)
 	if err != nil {
-		t.Errorf("Failed to list /test: %v", err)
+		t.Fatalf("Failed to list '/test': %v", err)
 	}
 	if len(values) != 0 {
-		t.Error("Expected 0 values in list response")
+		t.Fatal("Expected 0 values in list response")
 	}
 }
 
-func TestCreateAndList(t *testing.T) {
+func TestCreateAndListPrefix(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
 	err := testClient.Create(ctx, "/test/x", []byte("test"))
 	if err != nil {
-		t.Errorf("Failed to create /test/x: %v", err)
+		t.Fatalf("Failed to create '/test/x': %v", err)
 	}
 
 	values, err := testClient.List(ctx, "/test", 0)
 	if err != nil {
-		t.Errorf("Failed to list /test: %v", err)
+		t.Fatalf("Failed to list '/test': %v", err)
 	}
 
 	if len(values) != 1 {
-		t.Errorf("Expected 1 value in list response")
+		t.Fatal("Expected 1 value in list response")
 	}
 
 	for _, v := range values {

--- a/scripts/test
+++ b/scripts/test
@@ -5,9 +5,6 @@ cd $(dirname $0)/..
 
 . ./scripts/test-helpers
 
-#echo Running go unit tests
-go test -cover -tags=test ./...
-
 # ---
 
 docker ps

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -279,6 +279,12 @@ provision-database() {
 export -f provision-database
 
 # ---
+run-go-tests() {
+  go test -v -cover -tags=test ./...
+}
+export -f run-go-tests
+
+# ---
 
 pid-cleanup() {
     local code=$?

--- a/scripts/test-run-cockroachdb
+++ b/scripts/test-run-cockroachdb
@@ -23,6 +23,7 @@ start-test() {
     timeout --foreground 1m bash -c "wait-for-db-connection"
     KINE_IMAGE=$IMAGE KINE_ENDPOINT="postgres://root@$ip:$port/postgres?sslmode=disable$extra_params" provision-kine
     local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+    K3S_DATASTORE_ENDPOINT=$kine_url run-go-tests
     K3S_DATASTORE_ENDPOINT=$kine_url provision-cluster
 }
 export -f start-test

--- a/scripts/test-run-mysql
+++ b/scripts/test-run-mysql
@@ -18,6 +18,7 @@ start-test() {
     timeout --foreground 1m bash -c "wait-for-db-connection"
     KINE_IMAGE=$IMAGE KINE_ENDPOINT="mysql://root:$pass@tcp($ip:$port)/kine" provision-kine
     local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+    K3S_DATASTORE_ENDPOINT=$kine_url run-go-tests
     K3S_DATASTORE_ENDPOINT=$kine_url provision-cluster
 }
 export -f start-test

--- a/scripts/test-run-postgres
+++ b/scripts/test-run-postgres
@@ -18,6 +18,7 @@ start-test() {
     timeout --foreground 1m bash -c "wait-for-db-connection"
     KINE_IMAGE=$IMAGE KINE_ENDPOINT="postgres://postgres:$pass@$ip:$port/postgres?sslmode=disable" provision-kine
     local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+    K3S_DATASTORE_ENDPOINT=$kine_url run-go-tests
     K3S_DATASTORE_ENDPOINT=$kine_url provision-cluster
 }
 export -f start-test

--- a/scripts/test-run-sqlite
+++ b/scripts/test-run-sqlite
@@ -2,6 +2,7 @@
 start-test() {
     KINE_IMAGE=$IMAGE KINE_ENDPOINT="sqlite" provision-kine
     local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+    K3S_DATASTORE_ENDPOINT=$kine_url run-go-tests
     K3S_DATASTORE_ENDPOINT=$kine_url provision-cluster
 }
 export -f start-test

--- a/scripts/test-runner
+++ b/scripts/test-runner
@@ -12,9 +12,5 @@ test-setup
 provision-database $DB_ARGS
 start-test $@
 
-echo "Running go unit tests"
-kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
-K3S_DATASTORE_ENDPOINT=$kine_url go test -v -cover -tags=test ./...
-
 #echo "Running load tests"
 #./scripts/test-load

--- a/scripts/test-runner
+++ b/scripts/test-runner
@@ -12,4 +12,8 @@ test-setup
 provision-database $DB_ARGS
 start-test $@
 
-./scripts/test-load
+echo "Running go unit tests"
+go test -v -cover -tags=test ./...
+
+#echo "Running load tests"
+#./scripts/test-load

--- a/scripts/test-runner
+++ b/scripts/test-runner
@@ -13,8 +13,8 @@ provision-database $DB_ARGS
 start-test $@
 
 echo "Running go unit tests"
-env
-go test -v -cover -tags=test ./...
+local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+K3S_DATASTORE_ENDPOINT=$kine_url go test -v -cover -tags=test ./...
 
 #echo "Running load tests"
 #./scripts/test-load

--- a/scripts/test-runner
+++ b/scripts/test-runner
@@ -13,6 +13,7 @@ provision-database $DB_ARGS
 start-test $@
 
 echo "Running go unit tests"
+env
 go test -v -cover -tags=test ./...
 
 #echo "Running load tests"

--- a/scripts/test-runner
+++ b/scripts/test-runner
@@ -13,7 +13,7 @@ provision-database $DB_ARGS
 start-test $@
 
 echo "Running go unit tests"
-local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
 K3S_DATASTORE_ENDPOINT=$kine_url go test -v -cover -tags=test ./...
 
 #echo "Running load tests"


### PR DESCRIPTION
Add some tests to client; fix issue preventing Delete from working - it is only implemented within a transaction.

End goal is to fix error seen occasionally in CI:

```console
[[36mSERIAL-mysql[m] time="2021-06-25T19:57:18.673547050Z" level=info msg="Database tables and indexes are up to date"
[[36mSERIAL-mysql[m] time="2021-06-25T19:57:18.813165230Z" level=info msg="Kine listening on unix://kine.sock"
[[36mSERIAL-mysql[m] time="2021-06-25T19:57:18.816175405Z" level=error msg="error while range on /bootstrap /bootstrap: sql: Scan error on column index 0, name \"prev_revision\": converting NULL to int64 is unsupported"
[[36mSERIAL-mysql[m] {"level":"warn","ts":"2021-06-25T19:57:18.816Z","caller":"clientv3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"endpoint://client-165d6aa6-39a1-4403-a907-ed1b8e024777/kine.sock","attempt":0,"error":"rpc error: code = Unknown desc = sql: Scan error on column index 0, name \"prev_revision\": converting NULL to int64 is unsupported"}
[[36mSERIAL-mysql[m] time="2021-06-25T19:57:18.816382180Z" level=fatal msg="starting kubernetes: preparing server: rpc error: code = Unknown desc = sql: Scan error on column index 0, name \"prev_revision\": converting NULL to int64 is unsupported"
```