### PR TITLE
Ensure compaction runs during startup

### DIFF
--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -3,7 +3,7 @@ FROM golang:1.15-alpine3.12 AS dapper
 ARG ARCH=amd64
 
 RUN apk -U add bash coreutils git gcc musl-dev docker-cli vim less file curl wget ca-certificates
-RUN apk -U add py3-pip && pip install kubernetes termplotlib
+RUN apk -U add py3-pip && pip install kubernetes termplotlib==v0.3.4
 
 ENV DAPPER_RUN_ARGS --privileged -v kine-cache:/go/src/github.com/k3s-io/kine/.cache
 ENV DAPPER_ENV ARCH REPO TAG DRONE_TAG IMAGE_NAME CROSS

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -53,9 +53,9 @@ type Dialect interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*generic.Tx, error)
 }
 
-func (s *SQLLog) Start(ctx context.Context) (err error) {
+func (s *SQLLog) Start(ctx context.Context) error {
 	s.ctx = ctx
-	return
+	return s.compactStart(s.ctx)
 }
 
 func (s *SQLLog) compactStart(ctx context.Context) error {
@@ -365,10 +365,6 @@ func filter(events interface{}, checkPrefix bool, prefix string) ([]*server.Even
 }
 
 func (s *SQLLog) startWatch() (chan interface{}, error) {
-	if err := s.compactStart(s.ctx); err != nil {
-		return nil, err
-	}
-
 	pollStart, err := s.d.GetCompactRevision(s.ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Ensure that initial compaction runs during Start. Deferring this until
Watch creates a race condition wherein we can start answering
requests before compact_rev_key is created, which will cause SQL errors
as seen in k3s-io/k3s#3523.

* Fix client.Delete; the current implementation does not actually work
because delete is only implemented within transactions.

* Fix CI tests by pinning the library we're using to output perf stats