### PR TITLE
Add support for etcd version, memberList, and status queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/wrangler v0.8.3
 	github.com/sirupsen/logrus v1.7.0
+	github.com/soheilhy/cmux v0.1.5
 	github.com/urfave/cli v1.21.0
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 	go.etcd.io/etcd/api/v3 v3.5.0

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/k3s-io/kine/pkg/endpoint"
+	"github.com/k3s-io/kine/pkg/version"
 	"github.com/rancher/wrangler/pkg/signals"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -18,7 +20,8 @@ var (
 func main() {
 	app := cli.NewApp()
 	app.Name = "kine"
-	app.Description = "Minimal etcd v3 API to support custom Kubernetes storage engines"
+	app.Usage = "Minimal etcd v3 API to support custom Kubernetes storage engines"
+	app.Version = fmt.Sprintf("%s (%s)", version.Version, version.GitCommit)
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:        "listen-address",

--- a/main.go
+++ b/main.go
@@ -19,11 +19,10 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "kine"
 	app.Description = "Minimal etcd v3 API to support custom Kubernetes storage engines"
-	app.Usage = "Mini"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:        "listen-address",
-			Value:       "tcp://0.0.0.0:2379",
+			Value:       "0.0.0.0:2379",
 			Destination: &config.Listener,
 		},
 		cli.StringFlag{

--- a/pkg/drivers/generic/tx.go
+++ b/pkg/drivers/generic/tx.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/k3s-io/kine/pkg/server"
 	"github.com/sirupsen/logrus"
 )
+
+// explicit interface check
+var _ server.Transaction = (*Tx)(nil)
 
 type Tx struct {
 	x *sql.Tx
 	d *Generic
 }
 
-func (d *Generic) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
+func (d *Generic) BeginTx(ctx context.Context, opts *sql.TxOptions) (server.Transaction, error) {
 	logrus.Tracef("TX BEGIN")
 	x, err := d.DB.BeginTx(ctx, opts)
 	if err != nil {

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -68,6 +68,10 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	}
 
 	dialect.LastInsertID = true
+	dialect.GetSizeSQL = `
+		SELECT SUM(data_length + index_length)
+		FROM information_schema.TABLES
+		WHERE table_schema = DATABASE() AND table_name = 'kine'`
 	dialect.CompactSQL = `
 		DELETE kv FROM kine AS kv
 		INNER JOIN (

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -58,6 +58,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 	if err != nil {
 		return nil, err
 	}
+	dialect.GetSizeSQL = `SELECT pg_total_relation_size('kine')`
 	dialect.CompactSQL = `
 		DELETE FROM kine AS kv
 		USING	(

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -61,6 +61,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connPool
 	}
 
 	dialect.LastInsertID = true
+	dialect.GetSizeSQL = `SELECT SUM(pgsize) FROM dbstat`
 	dialect.CompactSQL = `
 		DELETE FROM kine AS kv
 		WHERE

--- a/pkg/endpoint/http.go
+++ b/pkg/endpoint/http.go
@@ -1,0 +1,66 @@
+package endpoint
+
+import (
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+var (
+	etcdVersion = []byte(`{"etcdserver":"3.5.0","etcdcluster":"3.5.0"}`)
+	versionPath = "/version"
+)
+
+// httpServer returns a HTTP server with the basic mux handler.
+func httpServer() *http.Server {
+	// Set up root HTTP mux with basic response handlers
+	mux := http.NewServeMux()
+	handleBasic(mux)
+
+	return &http.Server{
+		Handler:  mux,
+		ErrorLog: log.New(logrus.StandardLogger().Writer(), "kinehttp ", log.LstdFlags),
+	}
+}
+
+// handleBasic binds basic HTTP response handlers to a mux.
+func handleBasic(mux *http.ServeMux) {
+	mux.HandleFunc(versionPath, serveVersion)
+}
+
+// serveVersion responds with a canned JSON version response.
+func serveVersion(w http.ResponseWriter, r *http.Request) {
+	if !allowMethod(w, r, http.MethodGet) {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(etcdVersion)
+}
+
+// allowMethod returns true if a method is allowed, or false (after sending a
+// MethodNotAllowed error to the client) if it is not.
+func allowMethod(w http.ResponseWriter, r *http.Request, m string) bool {
+	if m == r.Method {
+		return true
+	}
+	w.Header().Set("Allow", m)
+	http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	return false
+}
+
+// grpcHandlerFunc takes a GRPC server and HTTP handler, and returns a handler
+// function that will route GRPC requests to the GRPC server, and everything
+// else to the HTTP handler. This is based on sample code provided in the GRPC
+// ServeHTTP documentation for sharing a port between GRPC and HTTP handlers.
+func grpcHandlerFunc(grpcServer *grpc.Server, httpHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			httpHandler.ServeHTTP(w, r)
+		}
+	})
+}

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -17,6 +17,7 @@ type Log interface {
 	Watch(ctx context.Context, prefix string) <-chan []*server.Event
 	Count(ctx context.Context, prefix string) (int64, int64, error)
 	Append(ctx context.Context, event *server.Event) (int64, error)
+	DbSize(ctx context.Context) (int64, error)
 }
 
 type LogStructured struct {
@@ -366,4 +367,8 @@ func filter(events []*server.Event, rev int64) []*server.Event {
 	}
 
 	return events
+}
+
+func (l *LogStructured) DbSize(ctx context.Context) (int64, error) {
+	return l.log.DbSize(ctx)
 }

--- a/pkg/server/cluster.go
+++ b/pkg/server/cluster.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"google.golang.org/grpc/metadata"
+)
+
+// explicit interface check
+var _ etcdserverpb.ClusterServer = (*KVServerBridge)(nil)
+
+func (s *KVServerBridge) MemberAdd(context.Context, *etcdserverpb.MemberAddRequest) (*etcdserverpb.MemberAddResponse, error) {
+	return nil, fmt.Errorf("member add is not supported")
+}
+
+func (s *KVServerBridge) MemberRemove(context.Context, *etcdserverpb.MemberRemoveRequest) (*etcdserverpb.MemberRemoveResponse, error) {
+	return nil, fmt.Errorf("member remove is not supported")
+}
+
+func (s *KVServerBridge) MemberUpdate(context.Context, *etcdserverpb.MemberUpdateRequest) (*etcdserverpb.MemberUpdateResponse, error) {
+	return nil, fmt.Errorf("member update is not supported")
+}
+
+func (s *KVServerBridge) MemberList(ctx context.Context, r *etcdserverpb.MemberListRequest) (*etcdserverpb.MemberListResponse, error) {
+	listenURL := authorityURL(ctx, s.limited.scheme)
+	return &etcdserverpb.MemberListResponse{
+		Header: &etcdserverpb.ResponseHeader{},
+		Members: []*etcdserverpb.Member{
+			{
+				Name:       "kine",
+				ClientURLs: []string{listenURL},
+				PeerURLs:   []string{listenURL},
+			},
+		},
+	}, nil
+}
+
+func (s *KVServerBridge) MemberPromote(context.Context, *etcdserverpb.MemberPromoteRequest) (*etcdserverpb.MemberPromoteResponse, error) {
+	return nil, fmt.Errorf("member promote is not supported")
+}
+
+// authorityURL returns the URL of the authority (host) that the client connected to.
+// If no scheme is included in the authority data, the provided scheme is used. If no
+// authority data is provided, the default etcd endpoint is used.
+func authorityURL(ctx context.Context, scheme string) string {
+	authority := "127.0.0.1:2379"
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		authList := md.Get(":authority")
+		if len(authList) > 0 {
+			authority = authList[0]
+			// etcd v3.5 encodes the endpoint address list as "#initially=[ADDRESS1;ADDRESS2]"
+			if strings.HasPrefix(authority, "#initially=[") {
+				authority = strings.TrimPrefix(authority, "#initially=[")
+				authority = strings.TrimSuffix(authority, "]")
+				authority = strings.ReplaceAll(authority, ";", ",")
+				return authority
+			}
+		}
+	}
+	return scheme + "://" + authority
+}

--- a/pkg/server/dbsize.go
+++ b/pkg/server/dbsize.go
@@ -1,0 +1,7 @@
+package server
+
+import "context"
+
+func (l *LimitedServer) dbSize(ctx context.Context) (int64, error) {
+	return l.backend.DbSize(ctx)
+}

--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+)
+
+// explicit interface check
+var _ etcdserverpb.KVServer = (*KVServerBridge)(nil)
+
+func (k *KVServerBridge) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*etcdserverpb.RangeResponse, error) {
+	if r.KeysOnly {
+		return nil, unsupported("keysOnly")
+	}
+
+	if r.MaxCreateRevision != 0 {
+		return nil, unsupported("maxCreateRevision")
+	}
+
+	if r.SortOrder != 0 {
+		return nil, unsupported("sortOrder")
+	}
+
+	if r.SortTarget != 0 {
+		return nil, unsupported("sortTarget")
+	}
+
+	if r.Serializable {
+		return nil, unsupported("serializable")
+	}
+
+	if r.KeysOnly {
+		return nil, unsupported("keysOnly")
+	}
+
+	if r.MinModRevision != 0 {
+		return nil, unsupported("minModRevision")
+	}
+
+	if r.MinCreateRevision != 0 {
+		return nil, unsupported("minCreateRevision")
+	}
+
+	if r.MaxCreateRevision != 0 {
+		return nil, unsupported("maxCreateRevision")
+	}
+
+	if r.MaxModRevision != 0 {
+		return nil, unsupported("maxModRevision")
+	}
+
+	resp, err := k.limited.Range(ctx, r)
+	if err != nil {
+		logrus.Errorf("error while range on %s %s: %v", r.Key, r.RangeEnd, err)
+		return nil, err
+	}
+
+	rangeResponse := &etcdserverpb.RangeResponse{
+		More:   resp.More,
+		Count:  resp.Count,
+		Header: resp.Header,
+		Kvs:    toKVs(resp.Kvs...),
+	}
+
+	return rangeResponse, nil
+}
+
+func toKVs(kvs ...*KeyValue) []*mvccpb.KeyValue {
+	if len(kvs) == 0 || kvs[0] == nil {
+		return nil
+	}
+
+	ret := make([]*mvccpb.KeyValue, 0, len(kvs))
+	for _, kv := range kvs {
+		newKV := toKV(kv)
+		if newKV != nil {
+			ret = append(ret, newKV)
+		}
+	}
+	return ret
+}
+
+func toKV(kv *KeyValue) *mvccpb.KeyValue {
+	if kv == nil {
+		return nil
+	}
+	return &mvccpb.KeyValue{
+		Key:            []byte(kv.Key),
+		Value:          kv.Value,
+		Lease:          kv.Lease,
+		CreateRevision: kv.CreateRevision,
+		ModRevision:    kv.ModRevision,
+	}
+}
+
+func (k *KVServerBridge) Put(ctx context.Context, r *etcdserverpb.PutRequest) (*etcdserverpb.PutResponse, error) {
+	return nil, fmt.Errorf("put is not supported")
+}
+
+func (k *KVServerBridge) DeleteRange(ctx context.Context, r *etcdserverpb.DeleteRangeRequest) (*etcdserverpb.DeleteRangeResponse, error) {
+	return nil, fmt.Errorf("delete is not supported")
+}
+
+func (k *KVServerBridge) Txn(ctx context.Context, r *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
+	res, err := k.limited.Txn(ctx, r)
+	if err != nil {
+		logrus.Errorf("error in txn: %v", err)
+	}
+	return res, err
+}
+
+func (k *KVServerBridge) Compact(ctx context.Context, r *etcdserverpb.CompactionRequest) (*etcdserverpb.CompactionResponse, error) {
+	return &etcdserverpb.CompactionResponse{
+		Header: &etcdserverpb.ResponseHeader{
+			Revision: r.Revision,
+		},
+	}, nil
+}
+
+func unsupported(field string) error {
+	return fmt.Errorf("%s is unsupported", field)
+}

--- a/pkg/server/lease.go
+++ b/pkg/server/lease.go
@@ -7,6 +7,9 @@ import (
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
+// explicit interface check
+var _ etcdserverpb.LeaseServer = (*KVServerBridge)(nil)
+
 func (s *KVServerBridge) LeaseGrant(ctx context.Context, req *etcdserverpb.LeaseGrantRequest) (*etcdserverpb.LeaseGrantResponse, error) {
 	return &etcdserverpb.LeaseGrantResponse{
 		Header: &etcdserverpb.ResponseHeader{},

--- a/pkg/server/limited.go
+++ b/pkg/server/limited.go
@@ -9,6 +9,7 @@ import (
 
 type LimitedServer struct {
 	backend Backend
+	scheme  string
 }
 
 func (l *LimitedServer) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {

--- a/pkg/server/maintenance.go
+++ b/pkg/server/maintenance.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+// explicit interface check
+var _ etcdserverpb.MaintenanceServer = (*KVServerBridge)(nil)
+
+func (s *KVServerBridge) Alarm(context.Context, *etcdserverpb.AlarmRequest) (*etcdserverpb.AlarmResponse, error) {
+	return nil, fmt.Errorf("alarm is not supported")
+}
+
+func (s *KVServerBridge) Status(ctx context.Context, r *etcdserverpb.StatusRequest) (*etcdserverpb.StatusResponse, error) {
+	size, err := s.limited.dbSize(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &etcdserverpb.StatusResponse{
+		Header: &etcdserverpb.ResponseHeader{},
+		DbSize: size,
+	}, nil
+}
+
+func (s *KVServerBridge) Defragment(context.Context, *etcdserverpb.DefragmentRequest) (*etcdserverpb.DefragmentResponse, error) {
+	return nil, fmt.Errorf("defragment is not supported")
+}
+
+func (s *KVServerBridge) Hash(context.Context, *etcdserverpb.HashRequest) (*etcdserverpb.HashResponse, error) {
+	return nil, fmt.Errorf("hash is not supported")
+}
+
+func (s *KVServerBridge) HashKV(context.Context, *etcdserverpb.HashKVRequest) (*etcdserverpb.HashKVResponse, error) {
+	return nil, fmt.Errorf("hash kv is not supported")
+}
+
+func (s *KVServerBridge) Snapshot(*etcdserverpb.SnapshotRequest, etcdserverpb.Maintenance_SnapshotServer) error {
+	return fmt.Errorf("snapshot is not supported")
+}
+
+func (s *KVServerBridge) MoveLeader(context.Context, *etcdserverpb.MoveLeaderRequest) (*etcdserverpb.MoveLeaderResponse, error) {
+	return nil, fmt.Errorf("move leader is not supported")
+}
+
+func (s *KVServerBridge) Downgrade(context.Context, *etcdserverpb.DowngradeRequest) (*etcdserverpb.DowngradeResponse, error) {
+	return nil, fmt.Errorf("downgrade is not supported")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,30 +1,21 @@
 package server
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	"go.etcd.io/etcd/api/v3/mvccpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-)
-
-var (
-	_ etcdserverpb.KVServer    = (*KVServerBridge)(nil)
-	_ etcdserverpb.WatchServer = (*KVServerBridge)(nil)
 )
 
 type KVServerBridge struct {
 	limited *LimitedServer
 }
 
-func New(backend Backend) *KVServerBridge {
+func New(backend Backend, scheme string) *KVServerBridge {
 	return &KVServerBridge{
 		limited: &LimitedServer{
 			backend: backend,
+			scheme:  scheme,
 		},
 	}
 }
@@ -33,121 +24,9 @@ func (k *KVServerBridge) Register(server *grpc.Server) {
 	etcdserverpb.RegisterLeaseServer(server, k)
 	etcdserverpb.RegisterWatchServer(server, k)
 	etcdserverpb.RegisterKVServer(server, k)
+	etcdserverpb.RegisterClusterServer(server, k)
 
 	hsrv := health.NewServer()
 	hsrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	healthpb.RegisterHealthServer(server, hsrv)
-}
-
-func (k *KVServerBridge) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*etcdserverpb.RangeResponse, error) {
-	if r.KeysOnly {
-		return nil, unsupported("keysOnly")
-	}
-
-	if r.MaxCreateRevision != 0 {
-		return nil, unsupported("maxCreateRevision")
-	}
-
-	if r.SortOrder != 0 {
-		return nil, unsupported("sortOrder")
-	}
-
-	if r.SortTarget != 0 {
-		return nil, unsupported("sortTarget")
-	}
-
-	if r.Serializable {
-		return nil, unsupported("serializable")
-	}
-
-	if r.KeysOnly {
-		return nil, unsupported("keysOnly")
-	}
-
-	if r.MinModRevision != 0 {
-		return nil, unsupported("minModRevision")
-	}
-
-	if r.MinCreateRevision != 0 {
-		return nil, unsupported("minCreateRevision")
-	}
-
-	if r.MaxCreateRevision != 0 {
-		return nil, unsupported("maxCreateRevision")
-	}
-
-	if r.MaxModRevision != 0 {
-		return nil, unsupported("maxModRevision")
-	}
-
-	resp, err := k.limited.Range(ctx, r)
-	if err != nil {
-		logrus.Errorf("error while range on %s %s: %v", r.Key, r.RangeEnd, err)
-		return nil, err
-	}
-
-	rangeResponse := &etcdserverpb.RangeResponse{
-		More:   resp.More,
-		Count:  resp.Count,
-		Header: resp.Header,
-		Kvs:    toKVs(resp.Kvs...),
-	}
-
-	return rangeResponse, nil
-}
-
-func toKVs(kvs ...*KeyValue) []*mvccpb.KeyValue {
-	if len(kvs) == 0 || kvs[0] == nil {
-		return nil
-	}
-
-	ret := make([]*mvccpb.KeyValue, 0, len(kvs))
-	for _, kv := range kvs {
-		newKV := toKV(kv)
-		if newKV != nil {
-			ret = append(ret, newKV)
-		}
-	}
-	return ret
-}
-
-func toKV(kv *KeyValue) *mvccpb.KeyValue {
-	if kv == nil {
-		return nil
-	}
-	return &mvccpb.KeyValue{
-		Key:            []byte(kv.Key),
-		Value:          kv.Value,
-		Lease:          kv.Lease,
-		CreateRevision: kv.CreateRevision,
-		ModRevision:    kv.ModRevision,
-	}
-}
-
-func (k *KVServerBridge) Put(ctx context.Context, r *etcdserverpb.PutRequest) (*etcdserverpb.PutResponse, error) {
-	return nil, fmt.Errorf("put is not supported")
-}
-
-func (k *KVServerBridge) DeleteRange(ctx context.Context, r *etcdserverpb.DeleteRangeRequest) (*etcdserverpb.DeleteRangeResponse, error) {
-	return nil, fmt.Errorf("delete is not supported")
-}
-
-func (k *KVServerBridge) Txn(ctx context.Context, r *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
-	res, err := k.limited.Txn(ctx, r)
-	if err != nil {
-		logrus.Errorf("error in txn: %v", err)
-	}
-	return res, err
-}
-
-func (k *KVServerBridge) Compact(ctx context.Context, r *etcdserverpb.CompactionRequest) (*etcdserverpb.CompactionResponse, error) {
-	return &etcdserverpb.CompactionResponse{
-		Header: &etcdserverpb.ResponseHeader{
-			Revision: r.Revision,
-		},
-	}, nil
-}
-
-func unsupported(field string) error {
-	return fmt.Errorf("%s is unsupported", field)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,7 @@ func (k *KVServerBridge) Register(server *grpc.Server) {
 	etcdserverpb.RegisterWatchServer(server, k)
 	etcdserverpb.RegisterKVServer(server, k)
 	etcdserverpb.RegisterClusterServer(server, k)
+	etcdserverpb.RegisterMaintenanceServer(server, k)
 
 	hsrv := health.NewServer()
 	hsrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 )
@@ -20,6 +21,38 @@ type Backend interface {
 	Count(ctx context.Context, prefix string) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
 	Watch(ctx context.Context, key string, revision int64) <-chan []*Event
+	DbSize(ctx context.Context) (int64, error)
+}
+
+type Dialect interface {
+	ListCurrent(ctx context.Context, prefix string, limit int64, includeDeleted bool) (*sql.Rows, error)
+	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted bool) (*sql.Rows, error)
+	Count(ctx context.Context, prefix string) (int64, int64, error)
+	CurrentRevision(ctx context.Context) (int64, error)
+	After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
+	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (int64, error)
+	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
+	DeleteRevision(ctx context.Context, revision int64) error
+	GetCompactRevision(ctx context.Context) (int64, error)
+	SetCompactRevision(ctx context.Context, revision int64) error
+	Compact(ctx context.Context, revision int64) (int64, error)
+	Fill(ctx context.Context, revision int64) error
+	IsFill(key string) bool
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (Transaction, error)
+	GetSize(ctx context.Context) (int64, error)
+}
+
+type Transaction interface {
+	Commit() error
+	MustCommit()
+	Rollback() error
+	MustRollback()
+	GetCompactRevision(ctx context.Context) (int64, error)
+	SetCompactRevision(ctx context.Context, revision int64) error
+	Compact(ctx context.Context, revision int64) (int64, error)
+	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
+	DeleteRevision(ctx context.Context, revision int64) error
+	CurrentRevision(ctx context.Context) (int64, error)
 }
 
 type KeyValue struct {

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -10,9 +10,10 @@ import (
 	"go.etcd.io/etcd/api/v3/mvccpb"
 )
 
-var (
-	watchID int64
-)
+var watchID int64
+
+// explicit interface check
+var _ etcdserverpb.WatchServer = (*KVServerBridge)(nil)
 
 func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	w := watcher{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	Version   = "dev"
+	GitCommit = "HEAD"
+)

--- a/scripts/build
+++ b/scripts/build
@@ -9,11 +9,11 @@ mkdir -p bin
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
-LINKFLAGS="-X github.com/k3s-io/kine.Version=$VERSION"
-LINKFLAGS="-X github.com/k3s-io/kine.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
+LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Kine
-go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/kine
+CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/kine
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/kine-darwin
     GOOS=windows go build -ldflags "$LINKFLAGS" -o bin/kine-windows


### PR DESCRIPTION
In upstream etcd, the version endpoint is implemented as a simple JSON handler, muxed with the GRPC server on the client port. This PR implements the required muxing for both plaintext and TLS listeners, using an approach inspired by upstream etcd. Kine now sends a hardcoded etcd version response that should satisfy clients such as kubeadm's [preflight checks](https://github.com/kubernetes/kubernetes/blob/release-1.21/cmd/kubeadm/app/preflight/checks.go#L694) (fixing #30).

This PR also splits the server code into different files per GRPC service, and adds a Cluster service that only supports GetMembers. The service returns a fixed member list that uses the GRPC ":authority" metadata (analogous to the HTTP Host header) to set the returned peer and client URLs. This should be sufficient to satisfy clients such as [KCP](https://github.com/kcp-dev/kcp) that enumerate the etcd member list as an informational [startup check](https://github.com/kcp-dev/kcp/blob/main/cmd/kcp/kcp.go#L105).

Third, this PR adds a Maintenance service that only supports Status, populating the DbSize field if the driver has a query to report this data. Currently sqlite, mysql, and postgres all support this; cockroachdb does not. This field is periodically collected by the Kubernetes apiserver and copied into the etcd_db_total_size_in_bytes metric.