### PR TITLE
Call wal_checkpoint during startup/compact for sqlite

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -94,6 +94,7 @@ type Generic struct {
 	DeleteSQL             string
 	CompactSQL            string
 	UpdateCompactSQL      string
+	PostCompactSQL        string
 	InsertSQL             string
 	FillSQL               string
 	InsertLastInsertIDSQL string
@@ -295,6 +296,15 @@ func (d *Generic) Compact(ctx context.Context, revision int64) (int64, error) {
 		return 0, err
 	}
 	return res.RowsAffected()
+}
+
+func (d *Generic) PostCompact(ctx context.Context) error {
+	logrus.Trace("POSTCOMPACT")
+	if d.PostCompactSQL != "" {
+		_, err := d.execute(ctx, d.PostCompactSQL)
+		return err
+	}
+	return nil
 }
 
 func (d *Generic) GetRevision(ctx context.Context, revision int64) (*sql.Rows, error) {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -39,6 +39,7 @@ var (
 		`CREATE INDEX IF NOT EXISTS kine_id_deleted_index ON kine (id,deleted)`,
 		`CREATE INDEX IF NOT EXISTS kine_prev_revision_index ON kine (prev_revision)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS kine_name_prev_revision_uindex ON kine (name, prev_revision)`,
+		`PRAGMA wal_checkpoint(TRUNCATE)`,
 	}
 )
 
@@ -79,6 +80,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connPool
 					kd.deleted != 0 AND
 					kd.id <= ?
 			)`
+	dialect.PostCompactSQL = `PRAGMA wal_checkpoint(FULL)`
 	dialect.TranslateErr = func(err error) error {
 		if err, ok := err.(sqlite3.Error); ok && err.ExtendedCode == sqlite3.ErrConstraintUnique {
 			return server.ErrKeyExists

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -155,6 +155,10 @@ outer:
 			}
 		}
 
+		if err := s.postCompact(); err != nil {
+			logrus.Errorf("Post-compact operations failed: %v", err)
+		}
+
 		// Record the final results for the outer loop
 		compactRev = compactedRev
 		targetCompactRev = currentRev
@@ -216,6 +220,11 @@ func (s *SQLLog) compact(compactRev int64, targetCompactRev int64) (int64, int64
 	logrus.Debugf("COMPACT deleted %d rows from %d revisions in %s - compacted to %d/%d", deletedRows, (targetCompactRev - compactRev), time.Since(start), targetCompactRev, currentRev)
 
 	return targetCompactRev, currentRev, nil
+}
+
+// postCompact executes any post-compact database cleanup - vacuuming, WAL truncate, etc.
+func (s *SQLLog) postCompact() error {
+	return s.d.PostCompact(s.ctx)
 }
 
 func (s *SQLLog) CurrentRevision(ctx context.Context) (int64, error) {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -36,6 +36,7 @@ type Dialect interface {
 	GetCompactRevision(ctx context.Context) (int64, error)
 	SetCompactRevision(ctx context.Context, revision int64) error
 	Compact(ctx context.Context, revision int64) (int64, error)
+	PostCompact(ctx context.Context) error
 	Fill(ctx context.Context, revision int64) error
 	IsFill(key string) bool
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (Transaction, error)


### PR DESCRIPTION
This should address https://github.com/k3s-io/k3s/issues/3660

As discussed at https://github.com/k3s-io/k3s/issues/4044#issuecomment-928322661, highly active clusters can cause checkpoint starvation due to there always being an active reader. Forcing a checkpoint at the end of compaction should prevent this from occurring, at the cost of blocking writers for a short period. This should not be any worse than the blocking that currently occurs for the compact transaction.

This also adds a WAL truncate at startup, which should shrink the on-disk WAL back down to a reasonable size for users whose files have grown out of control due to the issue described above.

https://sqlite.org/pragma.html#pragma_wal_checkpoint

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>