### PR TITLE
Introduce metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/nats-io/jsm.go v0.0.31-0.20220317133147-fe318f464eee
 	github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/rancher/wrangler v0.8.3
 	github.com/shengdoushi/base58 v1.0.0
 	github.com/sirupsen/logrus v1.7.0

--- a/pkg/drivers/dqlite/dqlite.go
+++ b/pkg/drivers/dqlite/dqlite.go
@@ -19,6 +19,7 @@ import (
 	"github.com/k3s-io/kine/pkg/drivers/sqlite"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -68,7 +69,7 @@ outer:
 	return nil
 }
 
-func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
 	opts, err := parseOpts(datasourceName)
 	if err != nil {
 		return nil, err
@@ -97,7 +98,7 @@ func New(ctx context.Context, datasourceName string, connPoolConfig generic.Conn
 	}
 
 	sql.Register("dqlite", d)
-	backend, generic, err := sqlite.NewVariant(ctx, "dqlite", opts.dsn, connPoolConfig)
+	backend, generic, err := sqlite.NewVariant(ctx, "dqlite", opts.dsn, connPoolConfig, metricsRegisterer)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlite client")
 	}

--- a/pkg/drivers/dqlite/no_dqlite.go
+++ b/pkg/drivers/dqlite/no_dqlite.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/k3s-io/kine/pkg/drivers/generic"
 	"github.com/k3s-io/kine/pkg/server"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, datasourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
 	return nil, errors.New(`this binary is built without dqlite support, compile with "-tags dqlite"`)
 }

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	cryptotls "crypto/tls"
 	"database/sql"
+	"fmt"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/k3s-io/kine/pkg/drivers/generic"
@@ -11,6 +12,8 @@ import (
 	"github.com/k3s-io/kine/pkg/logstructured/sqllog"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/k3s-io/kine/pkg/tls"
+	"github.com/k3s-io/kine/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -43,7 +46,7 @@ var (
 	createDB = "CREATE DATABASE IF NOT EXISTS "
 )
 
-func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
 	tlsConfig, err := tlsInfo.ClientConfig()
 	if err != nil {
 		return nil, err
@@ -62,7 +65,7 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 		return nil, err
 	}
 
-	dialect, err := generic.Open(ctx, "mysql", parsedDSN, connPoolConfig, "?", false)
+	dialect, err := generic.Open(ctx, "mysql", parsedDSN, connPoolConfig, "?", false, metricsRegisterer)
 	if err != nil {
 		return nil, err
 	}
@@ -95,6 +98,15 @@ func New(ctx context.Context, dataSourceName string, tlsInfo tls.Config, connPoo
 		}
 		return err
 	}
+	dialect.ErrCode = func(err error) string {
+		if err == nil {
+			return ""
+		}
+		if err, ok := err.(*mysql.MySQLError); ok {
+			return fmt.Sprint(err.Number)
+		}
+		return err.Error()
+	}
 	if err := setup(dialect.DB); err != nil {
 		return nil, err
 	}
@@ -107,7 +119,7 @@ func setup(db *sql.DB) error {
 	logrus.Infof("Configuring database table schema and indexes, this may take a moment...")
 
 	for _, stmt := range schema {
-		logrus.Tracef("SETUP EXEC : %v", generic.Stripped(stmt))
+		logrus.Tracef("SETUP EXEC : %v", util.Stripped(stmt))
 		_, err := db.Exec(stmt)
 		if err != nil {
 			if mysqlError, ok := err.(*mysql.MySQLError); !ok || mysqlError.Number != 1061 {

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -10,15 +10,16 @@ import (
 
 	"github.com/k3s-io/kine/pkg/drivers/generic"
 	"github.com/k3s-io/kine/pkg/server"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var errNoCgo = errors.New("this binary is built without CGO, sqlite is disabled")
 
-func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, error) {
+func New(ctx context.Context, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, error) {
 	return nil, errNoCgo
 }
 
-func NewVariant(driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig) (server.Backend, *generic.Generic, error) {
+func NewVariant(driverName, dataSourceName string, connPoolConfig generic.ConnectionPoolConfig, metricsRegisterer prometheus.Registerer) (server.Backend, *generic.Generic, error) {
 	return nil, nil, errNoCgo
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -13,9 +13,11 @@ import (
 	"github.com/k3s-io/kine/pkg/drivers/mysql"
 	"github.com/k3s-io/kine/pkg/drivers/pgsql"
 	"github.com/k3s-io/kine/pkg/drivers/sqlite"
+	"github.com/k3s-io/kine/pkg/metrics"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/k3s-io/kine/pkg/tls"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/soheilhy/cmux"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -41,6 +43,7 @@ type Config struct {
 	ConnectionPoolConfig generic.ConnectionPoolConfig
 	ServerTLSConfig      tls.Config
 	BackendTLSConfig     tls.Config
+	MetricsRegisterer    prometheus.Registerer
 }
 
 type ETCDConfig struct {
@@ -62,6 +65,14 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	leaderelect, backend, err := getKineStorageBackend(ctx, driver, dsn, config)
 	if err != nil {
 		return ETCDConfig{}, errors.Wrap(err, "building kine")
+	}
+
+	if config.MetricsRegisterer != nil {
+		config.MetricsRegisterer.MustRegister(
+			metrics.SQLTotal,
+			metrics.SQLTime,
+			metrics.CompactTotal,
+		)
 	}
 
 	if err := backend.Start(ctx); err != nil {
@@ -228,13 +239,13 @@ func getKineStorageBackend(ctx context.Context, driver, dsn string, cfg Config) 
 	switch driver {
 	case SQLiteBackend:
 		leaderElect = false
-		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
+		backend, err = sqlite.New(ctx, dsn, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
 	case DQLiteBackend:
-		backend, err = dqlite.New(ctx, dsn, cfg.ConnectionPoolConfig)
+		backend, err = dqlite.New(ctx, dsn, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
 	case PostgresBackend:
-		backend, err = pgsql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig)
+		backend, err = pgsql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
 	case MySQLBackend:
-		backend, err = mysql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig)
+		backend, err = mysql.New(ctx, dsn, cfg.BackendTLSConfig, cfg.ConnectionPoolConfig, cfg.MetricsRegisterer)
 	case JetStreamBackend:
 		backend, err = jetstream.New(ctx, dsn, cfg.BackendTLSConfig)
 	default:

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/k3s-io/kine/pkg/broadcaster"
+	"github.com/k3s-io/kine/pkg/metrics"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -150,6 +151,7 @@ outer:
 					break
 				} else {
 					logrus.Errorf("Compact failed: %v", err)
+					metrics.CompactTotal.WithLabelValues(metrics.ResultError).Inc()
 					continue outer
 				}
 			}
@@ -162,6 +164,8 @@ outer:
 		// Record the final results for the outer loop
 		compactRev = compactedRev
 		targetCompactRev = currentRev
+
+		metrics.CompactTotal.WithLabelValues(metrics.ResultSuccess).Inc()
 	}
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,48 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/k3s-io/kine/pkg/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	ResultSuccess = "success"
+	ResultError   = "error"
+)
+
+var (
+	SQLTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kine_sql_total",
+		Help: "Total number of SQL operations",
+	}, []string{"error_code"})
+
+	SQLTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "kine_sql_time_seconds",
+		Help: "Length of time per SQL operation",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+			1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30},
+	}, []string{"error_code"})
+
+	CompactTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kine_compact_total",
+		Help: "Total number of compactions",
+	}, []string{"result"})
+)
+
+var (
+	// SlowSQLThreshold is a duration which SQL executed longer than will be logged.
+	// This can be directly modified to override the default value when kine is used as a library.
+	SlowSQLThreshold = time.Second
+)
+
+func ObserveSQL(start time.Time, errCode string, sql util.Stripped, args ...interface{}) {
+	SQLTotal.WithLabelValues(errCode).Inc()
+	duration := time.Since(start)
+	SQLTime.WithLabelValues(errCode).Observe(duration.Seconds())
+	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold {
+		logrus.Infof("Slow SQL (started: %v) (total time: %v): %s : %v", start, duration, sql, args)
+	}
+}

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,0 +1,22 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+type RegistererGatherer interface {
+	prometheus.Registerer
+	prometheus.Gatherer
+}
+
+var Registry RegistererGatherer = prometheus.NewRegistry()
+
+func init() {
+	Registry.MustRegister(
+		// expose process metrics like CPU, Memory, file descriptor usage etc.
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		// expose Go runtime metrics like GC stats, memory stats etc.
+		collectors.NewGoCollector(),
+	)
+}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"github.com/k3s-io/kine/pkg/tls"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	ServerAddress   string
+	ServerTLSConfig tls.Config
+}
+
+const (
+	defaultBindAddress = ":8080"
+	metricsPath        = "/metrics"
+)
+
+func Serve(ctx context.Context, config Config) {
+	if config.ServerAddress == "" {
+		config.ServerAddress = defaultBindAddress
+	}
+	if config.ServerAddress == "0" {
+		return
+	}
+
+	logrus.Infof("metrics server is starting to listen at %s", config.ServerAddress)
+	listener, err := net.Listen("tcp", config.ServerAddress)
+	if err != nil {
+		logrus.Fatalf("error creating the metrics listener: %v", err)
+	}
+
+	handler := promhttp.HandlerFor(Registry, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	})
+	mux := http.NewServeMux()
+	mux.Handle(metricsPath, handler)
+	server := http.Server{
+		Handler: mux,
+	}
+
+	go func() {
+		logrus.Infof("starting metrics server path %s", metricsPath)
+		var err error
+		if config.ServerTLSConfig.CertFile != "" && config.ServerTLSConfig.KeyFile != "" {
+			err = server.ServeTLS(listener, config.ServerTLSConfig.CertFile, config.ServerTLSConfig.KeyFile)
+		} else {
+			err = server.Serve(listener)
+		}
+		if err != nil && err != http.ErrServerClosed {
+			logrus.Fatalf("error starting the metrics server: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	if err := server.Shutdown(context.Background()); err != nil {
+		logrus.Fatalf("error shutting down the metrics server: %v", err)
+	}
+}

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Stripped string
+
+func (s Stripped) String() string {
+	str := strings.ReplaceAll(string(s), "\n", "")
+	return regexp.MustCompile("[\t ]+").ReplaceAllString(str, " ")
+}


### PR DESCRIPTION
This PR introduce metrics to kine.

It'll expose below metrics:
* SQL Total & Errors: Counter metrics which hold the total number of SQL operations and failed SQL operations. This is helpful for quickly tracking and alerting local SQL errors which have a variant of causes (network, db, etc.) thus not easy to monitor.
* SQL Time: Histogram metric which keeps track of the duration of SQL operations. This duration is measured locally and can be used as a supplement to the SQL exec time measurement of db.
* Compact Errors: Counter metrics which hold the total number of compact errors. Helpful for alerting when continuous compact errors occur which can lead to uncontrollable growth of db size.
* [DBStats metrics](https://github.com/prometheus/client_golang/pull/866) of sql.DB used by kine.
* Process and Go runtime metrics when running stand-alone.

If kine is running stand-alone, we can use the `metrics-bind-address` flag to configure the metrics http server address or disable the server.
If kine is used as a library, we can set `MetricsRegisterer` of `endpoint.Config` to our own prometheus registerer to let kine register its metrics to it.

fixes #119 