### PR TITLE
Only enforce RangeEnd + Limit restriction when RangeEnd is set

### DIFF
--- a/pkg/drivers/jetstream/jetstream.go
+++ b/pkg/drivers/jetstream/jetstream.go
@@ -280,7 +280,7 @@ func (j *JetStream) isKeyExpired(_ context.Context, createTime time.Time, value 
 }
 
 // Get returns the associated server.KeyValue
-func (j *JetStream) Get(ctx context.Context, key string, revision int64) (revRet int64, kvRet *server.KeyValue, errRet error) {
+func (j *JetStream) Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (revRet int64, kvRet *server.KeyValue, errRet error) {
 	//logrus.Tracef("GET %s, rev=%d", key, revision)
 	start := time.Now()
 	defer func() {
@@ -674,7 +674,7 @@ func (j *JetStream) listAfter(ctx context.Context, prefix string, revision int64
 				KV:     kv.KV,
 				PrevKV: &server.KeyValue{},
 			}
-			if _, prevKV, err := j.Get(ctx, kv.KV.Key, kv.PrevRevision); err == nil && prevKV != nil {
+			if _, prevKV, err := j.Get(ctx, kv.KV.Key, "", 1, kv.PrevRevision); err == nil && prevKV != nil {
 				event.PrevKV = prevKV
 			}
 

--- a/pkg/server/get.go
+++ b/pkg/server/get.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {
-	if r.Limit != 0 {
+	if r.Limit != 0 && len(r.RangeEnd) != 0 {
 		return nil, fmt.Errorf("invalid combination of rangeEnd and limit, limit should be 0 got %d", r.Limit)
 	}
 
-	rev, kv, err := l.backend.Get(ctx, string(r.Key), r.Revision)
+	rev, kv, err := l.backend.Get(ctx, string(r.Key), string(r.RangeEnd), r.Limit, r.Revision)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -14,7 +14,7 @@ var (
 
 type Backend interface {
 	Start(ctx context.Context) error
-	Get(ctx context.Context, key string, revision int64) (int64, *KeyValue, error)
+	Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (int64, *KeyValue, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)


### PR DESCRIPTION
Related to: https://github.com/rancher/rancher/issues/36922
Caused by: https://github.com/kubernetes/kubernetes/pull/108569

Get requests with a field-selector now create range requests that include a limit (page size) that is managed by the apiserver. Kine was enforcing an unconditional restriction on the limit not being set, when the apparent intention was to only prohibit use of limit + rangeEnd at the same time.

Kubernetes 1.24 will when searching within a namespace for a resource using FieldSelector on metatada.name, send a Get request for the fully qualified resource name, but with a non-zero limit:
`RangeRequest Key=/registry/services/specs/default/kubernetes RangeEnd= Limit=500 Revision=0 SortOrder=0 SortTarget=0 Serializable=false KeysOnly=false CountOnly=false`


Confirmed that this fixes use of fieldSelector with K3s 1.24.2