### PR TITLE
Bump nats client to v1.17.1-0.20220923

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lib/pq v1.10.2
 	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/nats-io/jsm.go v0.0.31-0.20220317133147-fe318f464eee
-	github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228
+	github.com/nats-io/nats.go v1.17.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rancher/wrangler v0.8.3

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lib/pq v1.10.2
 	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/nats-io/jsm.go v0.0.31-0.20220317133147-fe318f464eee
-	github.com/nats-io/nats.go v1.17.0
+	github.com/nats-io/nats.go v1.17.1-0.20220923204156-36d2b654c70f
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rancher/wrangler v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,6 @@ github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hl
 github.com/nats-io/nats-server/v2 v2.7.5-0.20220309212130-5c0d1999ff72 h1:Moe/K4fo/5FCNpE/TYrMt7sEPUuldBVJ0D4g/SWFkd0=
 github.com/nats-io/nats-server/v2 v2.7.5-0.20220309212130-5c0d1999ff72/go.mod h1:1vZ2Nijh8tcyNe8BDVyTviCd9NYzRbubQYiEHsvOQWc=
 github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
-github.com/nats-io/nats.go v1.17.0 h1:1jp5BThsdGlN91hW0k3YEfJbfACjiOYtUiLXG0RL4IE=
-github.com/nats-io/nats.go v1.17.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.17.1-0.20220923204156-36d2b654c70f h1:HPCi1mdDweg4Kwpp9Ej5zH0qylyo7vJ7aHPY6YjTNv4=
 github.com/nats-io/nats.go v1.17.1-0.20220923204156-36d2b654c70f/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,8 @@ github.com/nats-io/nats-server/v2 v2.7.5-0.20220309212130-5c0d1999ff72/go.mod h1
 github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.17.0 h1:1jp5BThsdGlN91hW0k3YEfJbfACjiOYtUiLXG0RL4IE=
 github.com/nats-io/nats.go v1.17.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats.go v1.17.1-0.20220923204156-36d2b654c70f h1:HPCi1mdDweg4Kwpp9Ej5zH0qylyo7vJ7aHPY6YjTNv4=
+github.com/nats-io/nats.go v1.17.1-0.20220923204156-36d2b654c70f/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/nats-io/jwt/v2 v2.2.1-0.20220113022732-58e87895b296/go.mod h1:0tqz9Hl
 github.com/nats-io/nats-server/v2 v2.7.5-0.20220309212130-5c0d1999ff72 h1:Moe/K4fo/5FCNpE/TYrMt7sEPUuldBVJ0D4g/SWFkd0=
 github.com/nats-io/nats-server/v2 v2.7.5-0.20220309212130-5c0d1999ff72/go.mod h1:1vZ2Nijh8tcyNe8BDVyTviCd9NYzRbubQYiEHsvOQWc=
 github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
-github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228 h1:czbQ9uYuV7dwLsh/0vpB+4rutgdLTYgoN5W5hf1S0eg=
-github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
+github.com/nats-io/nats.go v1.17.0 h1:1jp5BThsdGlN91hW0k3YEfJbfACjiOYtUiLXG0RL4IE=
+github.com/nats-io/nats.go v1.17.0/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nkeys v0.3.0 h1:cgM5tL53EvYRU+2YLXIK0G2mJtK12Ft9oeooSZMA2G8=
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/pkg/drivers/jetstream/jetstream.go
+++ b/pkg/drivers/jetstream/jetstream.go
@@ -893,24 +893,12 @@ func (j *JetStream) getPreviousEntry(ctx context.Context, entry nats.KeyValueEnt
 }
 
 // DbSize get the kineBucket size from JetStream.
-func (j *JetStream) DbSize(ctx context.Context) (int64, error) {
-	keySize, err := j.bucketSize(ctx, j.kvBucket.Bucket())
+func (j *JetStream) DbSize(context.Context) (int64, error) {
+	si, err := j.jetStream.StreamInfo("KV_" + j.kvBucket.Bucket())
 	if err != nil {
 		return -1, err
 	}
-	return keySize, nil
-}
-
-func (j *JetStream) bucketSize(ctx context.Context, bucket string) (int64, error) {
-	os, err := j.jetStream.ObjectStore(bucket)
-	if err != nil {
-		return -1, err
-	}
-	s, err := os.Status()
-	if err != nil {
-		return -1, err
-	}
-	return int64(s.Size()), nil
+	return int64(si.State.Bytes), nil
 }
 
 func encode(v JSValue) ([]byte, error) {

--- a/pkg/drivers/jetstream/jetstream.go
+++ b/pkg/drivers/jetstream/jetstream.go
@@ -894,11 +894,11 @@ func (j *JetStream) getPreviousEntry(ctx context.Context, entry nats.KeyValueEnt
 
 // DbSize get the kineBucket size from JetStream.
 func (j *JetStream) DbSize(context.Context) (int64, error) {
-	si, err := j.jetStream.StreamInfo("KV_" + j.kvBucket.Bucket())
+	status, err := j.kvBucket.Status()
 	if err != nil {
 		return -1, err
 	}
-	return int64(si.State.Bytes), nil
+	return int64(status.Bytes()), nil
 }
 
 func encode(v JSValue) ([]byte, error) {

--- a/pkg/drivers/jetstream/kv/kv.go
+++ b/pkg/drivers/jetstream/kv/kv.go
@@ -213,22 +213,22 @@ func (e *EncodedKV) Update(key string, value []byte, last uint64) (revision uint
 	return e.bucket.Update(ek, buf.Bytes(), last)
 }
 
-func (e *EncodedKV) Delete(key string) error {
+func (e *EncodedKV) Delete(key string, opts ...nats.DeleteOpt) error {
 	ek, err := e.keyCodec.Encode(key)
 	if err != nil {
 		return err
 	}
 
-	return e.bucket.Delete(ek)
+	return e.bucket.Delete(ek, opts...)
 }
 
-func (e *EncodedKV) Purge(key string) error {
+func (e *EncodedKV) Purge(key string, opts ...nats.DeleteOpt) error {
 	ek, err := e.keyCodec.Encode(key)
 	if err != nil {
 		return err
 	}
 
-	return e.bucket.Purge(ek)
+	return e.bucket.Purge(ek, opts...)
 }
 
 func (e *EncodedKV) Watch(keys string, opts ...nats.WatchOpt) (nats.KeyWatcher, error) {

--- a/scripts/test-run-jetstream
+++ b/scripts/test-run-jetstream
@@ -16,7 +16,7 @@ export -f start-test
 # test minimum supported version and most recent version of NATS
 VERSION_LIST="\
     nats 2.7.4
-    nats 2.9.0"
+    nats 2.9.1"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=NATS_JS_PASSWORD DB_ARGS="-js" DB_IMAGE=docker.io/library/$ENGINE:$VERSION run-test

--- a/scripts/test-run-jetstream
+++ b/scripts/test-run-jetstream
@@ -5,7 +5,7 @@ start-test() {
     local port=$(cat $TEST_DIR/databases/*/metadata/port)
     local pass=$(cat $TEST_DIR/databases/*/metadata/password)
     local image=$(cat $TEST_DIR/databases/*/metadata/image)
-    DB_CONNECTION_TEST="docker container run --rm --name connection-test --entrypoint /usr/local/bin/nats natsio/nats-box:0.8.1 server check connection --server=nats://$ip:$port" \
+    DB_CONNECTION_TEST="docker container run --rm --name connection-test --entrypoint /usr/local/bin/nats natsio/nats-box:0.13.1 server check connection --server=nats://$ip:$port" \
     timeout --foreground 1m bash -c "wait-for-db-connection"
     KINE_IMAGE=$IMAGE KINE_ENDPOINT="nats://$ip:$port" provision-kine
     local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
@@ -14,7 +14,8 @@ start-test() {
 export -f start-test
 
 VERSION_LIST="\
-    nats 2.7.4"
+    nats 2.8.4
+    nats 2.9.0"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=NATS_JS_PASSWORD DB_ARGS="-js" DB_IMAGE=docker.io/library/$ENGINE:$VERSION run-test

--- a/scripts/test-run-jetstream
+++ b/scripts/test-run-jetstream
@@ -5,7 +5,7 @@ start-test() {
     local port=$(cat $TEST_DIR/databases/*/metadata/port)
     local pass=$(cat $TEST_DIR/databases/*/metadata/password)
     local image=$(cat $TEST_DIR/databases/*/metadata/image)
-    DB_CONNECTION_TEST="docker container run --rm --name connection-test --entrypoint /usr/local/bin/nats natsio/nats-box:0.13.1 server check connection --server=nats://$ip:$port" \
+    DB_CONNECTION_TEST="docker container run --rm --name connection-test --entrypoint /usr/local/bin/nats docker.io/natsio/nats-box:0.13.0 server check connection --server=nats://$ip:$port" \
     timeout --foreground 1m bash -c "wait-for-db-connection"
     KINE_IMAGE=$IMAGE KINE_ENDPOINT="nats://$ip:$port" provision-kine
     local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
@@ -13,8 +13,9 @@ start-test() {
 }
 export -f start-test
 
+# test minimum supported version and most recent version of NATS
 VERSION_LIST="\
-    nats 2.8.4
+    nats 2.7.4
     nats 2.9.0"
 
 while read ENGINE VERSION; do


### PR DESCRIPTION
- Bumps the nats clinet to ~v1.17.0~ `v1.17.1-0.20220923204156-36d2b654c70f`
- Fixes the `DbSize` function to call Stream Info in order to get the stream size