### PR TITLE
Add ability to enable remote profiling using pprof

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,6 +91,11 @@ func main() {
 			Destination: &metrics.SlowSQLThreshold,
 			Value:       time.Second,
 		},
+		cli.BoolFlag{
+			Name:        "metrics-enable-profiling",
+			Usage:       "Enable net/http/pprof handlers on the metrics bind address. Default is false.",
+			Destination: &metricsConfig.EnableProfiling,
+		},
 		cli.BoolFlag{Name: "debug"},
 	}
 	app.Action = run

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/k3s-io/kine/pkg/tls"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -13,6 +14,7 @@ import (
 type Config struct {
 	ServerAddress   string
 	ServerTLSConfig tls.Config
+	EnableProfiling bool
 }
 
 const (
@@ -34,11 +36,21 @@ func Serve(ctx context.Context, config Config) {
 		logrus.Fatalf("error creating the metrics listener: %v", err)
 	}
 
+	mux := http.NewServeMux()
+
 	handler := promhttp.HandlerFor(Registry, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.HTTPErrorOnError,
 	})
-	mux := http.NewServeMux()
 	mux.Handle(metricsPath, handler)
+
+	if config.EnableProfiling {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+
 	server := http.Server{
 		Handler: mux,
 	}

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -36,11 +36,10 @@ func Serve(ctx context.Context, config Config) {
 		logrus.Fatalf("error creating the metrics listener: %v", err)
 	}
 
-	mux := http.NewServeMux()
-
 	handler := promhttp.HandlerFor(Registry, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.HTTPErrorOnError,
 	})
+	mux := http.NewServeMux()
 	mux.Handle(metricsPath, handler)
 
 	if config.EnableProfiling {


### PR DESCRIPTION
### What

This PR adds a new flag, which, when enabled, allows for remote profiling using `net/http/pprof` package, with the handlers mounted to the metrics server.

By default the flag is disabled, to ensure that the change is backwards-compatible.

### Why

This allows for ad-hoc and continuous (e.g. using https://pyroscope.io/) profiling, which is useful for finding memory / cpu bottlenecks.
