### PR TITLE
Failed delete must return a ResponseRange instead

### DIFF
--- a/pkg/server/delete.go
+++ b/pkg/server/delete.go
@@ -33,6 +33,23 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 		return nil, err
 	}
 
+	if !ok {
+		return &etcdserverpb.TxnResponse{
+			Header: txnHeader(rev),
+			Responses: []*etcdserverpb.ResponseOp{
+				{
+					Response: &etcdserverpb.ResponseOp_ResponseRange{
+						ResponseRange: &etcdserverpb.RangeResponse{
+							Header: txnHeader(rev),
+							Kvs:    toKVs(kv),
+						},
+					},
+				},
+			},
+			Succeeded: false,
+		}, nil
+	}
+
 	return &etcdserverpb.TxnResponse{
 		Header: txnHeader(rev),
 		Responses: []*etcdserverpb.ResponseOp{
@@ -45,6 +62,6 @@ func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) 
 				},
 			},
 		},
-		Succeeded: ok,
+		Succeeded: true,
 	}, nil
 }


### PR DESCRIPTION
### Summary

Follow-up PR for #145 to account for delete operations that do not succeed.

For more context see:

- https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L337-L338
- Slack discussion with sig-api-machinery https://kubernetes.slack.com/archives/C0EG7JC6T/p1668796684479099. The decision is that it's up to the etcd3 implementation to return a valid response, and on failed deletes this means return a `ResponseRange` instead (as it falls-through to a simple get response).

@brandond Apologies for the initial PR being incomplete, I'm testing this as I go as well :) With this change I don't see anything blowing up, so things should be fine now.