### PR TITLE
fix(mysql): quote database name in CREATE DATABASE statement

### DIFF
--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -5,6 +5,7 @@ import (
 	cryptotls "crypto/tls"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/k3s-io/kine/pkg/drivers/generic"
@@ -137,7 +138,7 @@ func createDBIfNotExist(dataSourceName string) error {
 	if err != nil {
 		return err
 	}
-	dbName := config.DBName
+	dbName := quoteIdentifier(config.DBName)
 
 	db, err := sql.Open("mysql", dataSourceName)
 	if err != nil {
@@ -187,4 +188,8 @@ func prepareDSN(dataSourceName string, tlsConfig *cryptotls.Config) (string, err
 	parsedDSN := config.FormatDSN()
 
 	return parsedDSN, nil
+}
+
+func quoteIdentifier(id string) string {
+	return "`" + strings.ReplaceAll(id, "`", "``") + "`"
 }

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -123,7 +123,7 @@ func createDBIfNotExist(dataSourceName string) error {
 		return err
 	}
 
-	dbName := strings.SplitN(u.Path, "/", 2)[1]
+	dbName := quoteIdentifier(strings.SplitN(u.Path, "/", 2)[1])
 	db, err := sql.Open("postgres", dataSourceName)
 	if err != nil {
 		return err
@@ -207,4 +207,8 @@ func prepareDSN(dataSourceName string, tlsInfo tls.Config) (string, error) {
 	}
 	u.RawQuery = params.Encode()
 	return u.String(), nil
+}
+
+func quoteIdentifier(id string) string {
+	return pq.QuoteIdentifier(id)
 }


### PR DESCRIPTION
In order to allow the full Unicode Basic Multilingual Plane,
the database name is now quoted in the CREATE DATABASE statement.

fixes #148 