### PR TITLE
Update readme + Restrict dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for Docker Images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Kine (Kine is not etcd)
 ==========================
 
-_NOTE: this repository has been recently (2020-11-19) moved out of the github.com/rancher org to github.com/k3s-io
+_NOTE: On 2020-11-19, this repository was moved out of the github.com/rancher org to github.com/k3s-io 
 supporting the [acceptance of K3s as a CNCF sandbox project](https://github.com/cncf/toc/pull/447)_.
 
 ---
 
-Kine is an etcdshim that translates etcd API to sqlite, Postgres, Mysql, and dqlite
+Kine is an etcdshim that translates etcd API to:
+- SQLite
+- Postgres
+- MySQL
+- Dqlite
+- NATS Jetstream
 
 ## Features
-- Can be ran standalone so any k8s (not just k3s) can use Kine
+- Can be ran standalone so any k8s (not just K3s) can use Kine
 - Implements a subset of etcdAPI (not usable at all for general purpose etcd)
 - Translates etcdTX calls into the desired API (Create, Update, Delete)
-- Backend drivers for dqlite, sqlite, Postgres, MySQL and NATS JetStream
+
+See an [example](/examples/minimal.md).


### PR DESCRIPTION
- This updates the readme to include NATS Jetstream.
- This add a dependabot configuration file so dependabot STOPS TOUCHING go.mod and only looks at docker images... also it only runs weekly :smile: 