### PR TITLE
 switch to registry.k8s.io

### DIFF
--- a/examples/minimal.md
+++ b/examples/minimal.md
@@ -93,7 +93,7 @@ clusterName: kubernetes
 controllerManager: {}
 dns:
   type: CoreDNS
-imageRepository: k8s.gcr.io
+imageRepository: registry.k8s.io
 kind: ClusterConfiguration
 kubernetesVersion: v1.17.0
 networking:


### PR DESCRIPTION
The main Kubernetes container registry is now defaulted to registry.k8s.io. See: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/.
Switching to the new registry in the using with kubeadm sample.