### PR TITLE
Remove updatecli tranformers

### DIFF
--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -35,8 +35,6 @@ sources:
       versionfilter:
         kind: "regex"
         pattern: '^go1\.20\.2$'
-    transformers:
-      - trimprefix: "go"
 
 # Validate read access to local repo
 ## continue to targets if the go version in the validate file doesn't match the goTag source
@@ -76,4 +74,3 @@ actions:
       draft: false
       mergemethod: squash
       parent: false # this would allow for making a PR to an upstream fork, if we ran updatecli from a fork
-


### PR DESCRIPTION
This resolves an error where updatecli trims some of the version information from the validation target.