### PR TITLE
Golang and Alpine image bumps

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16 AS dapper
+FROM golang:1.20-alpine3.17 AS dapper
 
 ARG ARCH=amd64
 

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.16 AS dapper
+FROM golang:1.20-alpine3.17 AS dapper
 
 ARG ARCH=amd64
 

--- a/Dockerfile.test.dapper
+++ b/Dockerfile.test.dapper
@@ -2,7 +2,7 @@ FROM golang:1.20-alpine3.17 AS dapper
 
 ARG ARCH=amd64
 
-RUN apk -U add bash coreutils git gcc musl-dev docker-cli vim less file curl wget ca-certificates
+RUN apk -U add bash ca-certificates coreutils curl docker-cli file findutils gcc git less musl-dev vim wget
 RUN apk -U add py3-pip && pip install kubernetes termplotlib==v0.3.4
 
 ENV DAPPER_RUN_ARGS --privileged -v kine-cache:/go/src/github.com/k3s-io/kine/.cache

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -114,13 +114,12 @@ export -f run-test
 
 # ---
 
-inc-count() {(
-    shopt -s extglob
-    local count=$(exec 2>/dev/null; ls -1d $TEST_DIR/$1/+([0-9]) | xargs -n1 basename | sort -n -r | head -1)
+inc-count() {
+    local count=$(find $TEST_DIR -mindepth 2 -maxdepth 2 -type d -regex ".*/$1/[0-9]+" -printf '%f\n' | sort -nr | head -1)
     count=$((count+1))
     mkdir -p $TEST_DIR/$1/$count/metadata
     echo $count
-)}
+}
 export -f inc-count
 
 # ---


### PR DESCRIPTION
This PR does:

1. Bump Golang and Alpine image versions to `golang:1.20-alpine3.17` following PR https://github.com/k3s-io/kine/pull/164.
2. Fixes a CI script failure (see [failed pipeline](https://drone-pr.k3s.io/k3s-io/kine/190/1/3)) due to an update to Busybox's version. Part of the fix comes from https://github.com/k3s-io/k3s/pull/6744.
    1. This fix requires to add the package `findutils` to `Dockerfile.test.dapper` in order for `find` to support `printf`).
        1. Re-ordered alphabetically the packages installed by `apk`.
    2. Also re-ordered the parameters ` -mindepth 2 -maxdepth 2 -type d` to make them work as expected and avoid failure:
```shell
find: warning: you have specified the global option -mindepth after the argument -type, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
```