### PR TITLE
Add config for golangci-lint

### DIFF
--- a/updatecli/updatecli.d/dockerfile-dapper-golangci-lint.yml
+++ b/updatecli/updatecli.d/dockerfile-dapper-golangci-lint.yml
@@ -1,0 +1,64 @@
+# We don't want to actually pull the "latest" channel, we want to get the latest release and pin it
+#  when the PR comes in, we should be testing that this is actually what we want
+---
+name: "Update Dockerfile.dapper to pull the latest golangci-lint version for install"
+scms:
+  kine:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: "{{ requiredEnv .github.token }}"
+      owner: "k3s-io"
+      repository: "kine"
+      branch: "master"
+  golangci-lint:
+    kind: "github"
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      username: "{{ requiredEnv .github.username }}"
+      token: "{{ requiredEnv .github.token }}"
+      owner: "golangci"
+      repository: "golangci-lint"
+      branch: "master"
+
+sources:
+  goLintLatestTag:
+    name: "Golangci Lint's most recent tag"
+    kind: "gittag"
+    scmid: "golangci-lint"
+    spec:
+      versionfilter:
+        kind: "latest"
+
+# Only change if the Dockerfile doesn't already match
+conditions:
+  dockerDapperGoLintMatches:
+    name: "Only update dockerfile if there is a newer version of golangci-lint"
+    kind: file
+    sourceid: goLintLatestTag
+    spec:
+      file: "Dockerfile.dapper"
+      matchpattern: 'golangci\/golangci-lint\/(v1\.\d*\.\d*)\/install\.sh'
+
+targets:
+  updateGolangciLint:
+    name: "Update the version of Golangci-lint"
+    kind: "file"
+    scmid: "kine"
+    spec:
+      file: "Dockerfile.dapper"
+      matchpattern: 'golangci\/golangci-lint\/(v1\.\d*\.\d*)\/install\.sh'
+      replacepattern: 'golangci/golangci-lint/{{ source `goLintLatestTag` }}/install.sh'
+
+actions:
+  # create a pull request which is not allowed to automerge
+   github:
+    kind: "github/pullrequest"
+    scmid: "kine"
+    spec:
+      automerge: false
+      draft: false
+      mergemethod: squash

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,31 +3,3 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
-k3s:
-  org: "k3s-io"
-  repo: "k3s"
-  branch: "master"
-kine:
-  org: "k3s-io"
-  repo: "kine"
-  branch: "master"
-go:
-  org: "golang"
-  repo: "go"
-  branch: "master"
-klipper_helm:
-  org: "k3s-io"
-  repo: "klipper-helm"
-  branch: "master"
-klipper_lb:
-  org: "k3s-io"
-  repo: "klipper-lb"
-  branch: "master"
-local_path_provisioner:
-  org: "rancher"
-  repo: "local-path-provisioner"
-  branch: "master"
-helm_controller:
-  org: "k3s-io"
-  repo: "helm-controller"
-  branch: "master"


### PR DESCRIPTION
This adds a config to updatecli to keep golangci-lint up to date.

As I added this config I realized that having the repo info in a single file causes synchronization issues, so I removed the repo data from the values.yaml.
I want people to be able to work on different updatecli configs atomically and make changes without getting merge conflicts or having to synchronize pull requests, if you need to add your repo data to a single file that gets in the way of that goal. I think it is unlikely to cause any really painful issues to have the repo data in the config itself rather than the values.yaml.