### PR TITLE
install golangci-lint from master

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -7,7 +7,7 @@ RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.9.5
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2/install.sh | sh -s;  \
+    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s;  \
     fi
 
 ENV DAPPER_RUN_ARGS --privileged -v kine-cache:/go/src/github.com/k3s-io/kine/.cache


### PR DESCRIPTION
This will use the golangci-lint installer that is on the master branch, per their [installation guide](https://golangci-lint.run/usage/install/). This will always install the latest golangci-lint version.