### PR TITLE
Install goimports from commit hash instead of tag

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,9 @@ FROM golang:1.20-alpine3.17 AS dapper
 ARG ARCH=amd64
 
 RUN apk -U add bash coreutils git gcc musl-dev docker-cli vim less file curl wget ca-certificates
-RUN GOPROXY=direct go install golang.org/x/tools/cmd/goimports@gopls/v0.9.5
+# go imports version gopls/v0.9.5
+# https://github.com/golang/tools/releases/latest
+RUN go install golang.org/x/tools/cmd/goimports@8a9de1b095ae54649c1dc503f4f718779bddb55f
 RUN rm -rf /go/src /go/pkg
 
 RUN if [ "${ARCH}" == "amd64" ]; then \


### PR DESCRIPTION
This enables the use of go proxy and module cache for the goimports install by installing the commit hash at HEAD where the tag is. If we install from the commit hash we no longer need to bypass the proxy and we will benefit from the extra resilience. 

The earlier trade-off was the intent to keep things easier to update by using a human identifiable tag name and lose the benefits of the go proxy and module cache. I am generating automation which will keep the version up to date more easily, so I want to resolve the go proxy issue. I want this to resolve first to avoid duplicate effort as I need to update automation to keep the hash up to date after this change.

For human readability I am adding a comment with the corresponding tag version, this allows humans to easily validate the automation. 