### PR TITLE
Remove repo info from global scope

### DIFF
--- a/updatecli/updatecli.d/updatecli.yml
+++ b/updatecli/updatecli.d/updatecli.yml
@@ -1,4 +1,9 @@
 # This small test makes sure that updatecli is working properly on a repo.
+# To test this:
+#   have "UPDATECLI_GITHUB_ACTOR" env set to your github username
+#   have "UPDATECLI_GITHUB_TOKEN" env set to your github token
+#   have the latest verison of updatecli installed
+#   'updatecli diff -v updatecli/values.yaml -c updatecli/updatecli.d/updatecli.yml'
 # In the future, more useful files should be added to this directory.
 ---
 name: "Introduce updatecli to repo and validate basic functionality"
@@ -11,9 +16,9 @@ scms:
       email: "{{ .github.email }}"
       username: "{{ requiredEnv .github.username }}"
       token: '{{ requiredEnv .github.token }}'
-      owner: "{{ .kine.org }}"
-      repository: "{{ .kine.repo }}"
-      branch: "{{ .kine.branch }}"
+      owner: k3s-io
+      repository: kine
+      branch: master
   go:
     kind: "github"
     spec:
@@ -21,9 +26,9 @@ scms:
       email: "{{ .github.email }}"
       username: "{{ requiredEnv .github.username }}"
       token: '{{ requiredEnv .github.token }}'
-      owner: "{{ .go.org }}"
-      repository: "{{ .go.repo }}"
-      branch: "{{ .go.branch }}"
+      owner: golang
+      repository: go
+      branch: master
 
 sources:
   # validate gittag parsing external public repos

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -3,31 +3,3 @@ github:
   email: "41898282+github-actions[bot]@users.noreply.github.com"
   username: "UPDATECLI_GITHUB_ACTOR"
   token: "UPDATECLI_GITHUB_TOKEN"
-k3s:
-  org: "k3s-io"
-  repo: "k3s"
-  branch: "master"
-kine:
-  org: "k3s-io"
-  repo: "kine"
-  branch: "master"
-go:
-  org: "golang"
-  repo: "go"
-  branch: "master"
-klipper_helm:
-  org: "k3s-io"
-  repo: "klipper-helm"
-  branch: "master"
-klipper_lb:
-  org: "k3s-io"
-  repo: "klipper-lb"
-  branch: "master"
-local_path_provisioner:
-  org: "rancher"
-  repo: "local-path-provisioner"
-  branch: "master"
-helm_controller:
-  org: "k3s-io"
-  repo: "helm-controller"
-  branch: "master"


### PR DESCRIPTION
While updating files I realized that having the repo information in the values file was going to cause synchronization issues.

This resolves this, expecting new configs to contain the owner and names of the repos they need.