### PR TITLE
SQLite: specify a busy timeout

### DIFF
--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -57,7 +57,7 @@ func NewVariant(ctx context.Context, driverName, dataSourceName string, connPool
 		if err := os.MkdirAll("./db", 0700); err != nil {
 			return nil, nil, err
 		}
-		dataSourceName = "./db/state.db?_journal=WAL&cache=shared"
+		dataSourceName = "./db/state.db?_journal=WAL&cache=shared&_busy_timeout=30000"
 	}
 
 	dialect, err := generic.Open(ctx, driverName, dataSourceName, connPoolConfig, "?", false, metricsRegisterer)


### PR DESCRIPTION
Under stress, concurrent operations (notably while garbage collection is in progress) can result in failed calls with error SQLITE_BUSY (database is locked).

The SQLITE_BUSY result code is an expected outcome when the database file could not be written (or in some cases read) because of concurrent activity: https://www.sqlite.org/rescode.html

SQLite ships a busy timeout retry mechanism as a PRAGMA (https://www.sqlite.org/pragma.html#pragma_busy_timeout), that can be set via go-sqlite3's connection string.

That makes go-sqlite3 retry operations that fail with SQLITE_BUSY transparently to users.

Fixes https://github.com/k3s-io/k3s/issues/8234