### PR TITLE
Revert "Fix SQLLog.compactor"

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -107,7 +107,6 @@ func (s *SQLLog) compactStart(ctx context.Context) error {
 // This logic is directly cribbed from k8s.io/apiserver/pkg/storage/etcd3/compact.go
 func (s *SQLLog) compactor(interval time.Duration) {
 	t := time.NewTicker(interval)
-	defer t.Stop()
 	compactRev, _ := s.d.GetCompactRevision(s.ctx)
 	targetCompactRev, _ := s.d.CurrentRevision(s.ctx)
 	logrus.Tracef("COMPACT starting compactRev=%d targetCompactRev=%d", compactRev, targetCompactRev)


### PR DESCRIPTION
This reverts commit 62205ba8f1c302ec5776ef03117c7e837485f80f.

Not sure why, as this goroutine runs forever, but it appears to be causing CI failures where etcd clients get stale data.