### PR TITLE
Properly return ErrCompacted/ErrFutureRev for get/list

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -59,10 +59,6 @@ func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, re
 
 func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, revision int64, includeDeletes bool) (int64, *server.Event, error) {
 	rev, events, err := l.log.List(ctx, key, rangeEnd, limit, revision, includeDeletes)
-	if err == server.ErrCompacted {
-		// ignore compacted when getting by revision
-		err = nil
-	}
 	if err != nil {
 		return 0, nil, err
 	}

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -287,11 +287,19 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 	}
 
 	if revision > 0 && len(result) == 0 {
-		// a zero length result won't have the compact revision so get it manually
+		// a zero length result won't have the compact or current revisions so get them manually
+		rev, err = s.d.CurrentRevision(ctx)
+		if err != nil {
+			return 0, nil, err
+		}
 		compact, err = s.d.GetCompactRevision(ctx)
 		if err != nil {
 			return 0, nil, err
 		}
+	}
+
+	if revision > rev {
+		return rev, result, server.ErrFutureRev
 	}
 
 	if revision > 0 && revision < compact {

--- a/pkg/server/get.go
+++ b/pkg/server/get.go
@@ -22,6 +22,7 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 	}
 	if kv != nil {
 		resp.Kvs = []*KeyValue{kv}
+		resp.Count = 1
 	}
 	return resp, nil
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -10,6 +10,7 @@ import (
 var (
 	ErrKeyExists = rpctypes.ErrGRPCDuplicateKey
 	ErrCompacted = rpctypes.ErrGRPCCompacted
+	ErrFutureRev = rpctypes.ErrGRPCFutureRev
 )
 
 type Backend interface {


### PR DESCRIPTION
Always send ErrCompacted when getting/listing compacted revisions; ignoring it for get by revision is not correct.
Always send ErrFutureRev when getting/listing future revisions; pretending that the requested revision is the current revision is not correct.

* For https://github.com/k3s-io/kine/issues/215