### PR TITLE
Fix multiple issues with Watch

### DIFF
--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -25,6 +26,7 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		if err != nil {
 			return nil, err
 		}
+		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", r.Key, r.RangeEnd, r.Revision, rev, count)
 		return &RangeResponse{
 			Header: txnHeader(rev),
 			Count:  count,
@@ -41,6 +43,7 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		return nil, err
 	}
 
+	logrus.Tracef("LIST key=%s, end=%s, revision=%d, currentRev=%d count=%d, limit=%d", r.Key, r.RangeEnd, r.Revision, rev, len(kvs), r.Limit)
 	resp := &RangeResponse{
 		Header: txnHeader(rev),
 		Count:  int64(len(kvs)),

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -25,7 +25,7 @@ type Backend interface {
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
 	Count(ctx context.Context, prefix string) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
-	Watch(ctx context.Context, key string, revision int64) <-chan []*Event
+	Watch(ctx context.Context, key string, revision int64) WatchResult
 	DbSize(ctx context.Context) (int64, error)
 }
 
@@ -75,6 +75,12 @@ type Event struct {
 	Create bool
 	KV     *KeyValue
 	PrevKV *KeyValue
+}
+
+type WatchResult struct {
+	CurrentRevision int64
+	CompactRevision int64
+	Events          <-chan []*Event
 }
 
 func unsupported(field string) error {


### PR DESCRIPTION
* Fixes an error where watching a compacted revision would return events, followed by an error. The watch is now immediately cancelled with an appropriate error, and the compact/current revision fields set.

* Fixes an error where a high event rate could flood the GRPC stream with single-event watch responses. The event channel reader now merges all available events, and sends them in a single watch message. This was most frequently an issue on sqlite, where all inserts are done locally and immediately wake the polling goroutine to send the event without any opportunity for batching.

Fixes pod watch events being dropped when using kine to reproduce the issue described at https://github.com/kubernetes/kubernetes/issues/121688 

Ref: SURE-6953