### PR TITLE
Attempt to continue when encountering errors in createDBIfNotExist

### DIFF
--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -137,7 +137,7 @@ func createDBIfNotExist(dataSourceName string) error {
 	u.Path = "/postgres"
 	db, err := sql.Open("pgx", u.String())
 	if err != nil {
-		logrus.Warnf("failed to ensure existence of database %s; unable to connect to database postgres: %v", dbName, err)
+		logrus.Warnf("failed to ensure existence of database %s: unable to connect to default postgres database: %v", dbName, err)
 		return nil
 	}
 	defer db.Close()

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -135,7 +135,6 @@ func createDBIfNotExist(dataSourceName string) error {
 
 	dbName := strings.SplitN(u.Path, "/", 2)[1]
 	u.Path = "/postgres"
-	var exists bool
 	db, err := sql.Open("pgx", u.String())
 	if err != nil {
 		logrus.Warnf("failed to ensure existence of database %s; unable to connect to database postgres: %v", dbName, err)
@@ -143,6 +142,7 @@ func createDBIfNotExist(dataSourceName string) error {
 	}
 	defer db.Close()
 
+	var exists bool
 	err = db.QueryRow("SELECT 1 FROM pg_database WHERE datname = $1", dbName).Scan(&exists)
 	if err != nil && err != sql.ErrNoRows {
 		logrus.Warnf("failed to check existence of database %s, going to attempt create: %v", dbName, err)

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -138,14 +138,14 @@ func createDBIfNotExist(dataSourceName string) error {
 	var exists bool
 	db, err := sql.Open("pgx", u.String())
 	if err != nil {
-		logrus.Warnf("failed to check existence of database %s; unable to connect to postgres database: %v", dbName, err)
-	} else {
-		defer db.Close()
+		logrus.Warnf("failed to ensure existence of database %s; unable to connect to database postgres: %v", dbName, err)
+		return nil
+	}
+	defer db.Close()
 
-		err = db.QueryRow("SELECT 1 FROM pg_database WHERE datname = $1", dbName).Scan(&exists)
-		if err != nil && err != sql.ErrNoRows {
-			logrus.Warnf("failed to check existence of database %s: %v", dbName, err)
-		}
+	err = db.QueryRow("SELECT 1 FROM pg_database WHERE datname = $1", dbName).Scan(&exists)
+	if err != nil && err != sql.ErrNoRows {
+		logrus.Warnf("failed to check existence of database %s, going to attempt create: %v", dbName, err)
 	}
 
 	stmt := createDB + dbName + ";"


### PR DESCRIPTION
The database might already exist even if we encounter errors in createDBIfNotExist, so instead of erroring out, log warnings and attempt to continue.

Fixes https://github.com/k3s-io/k3s/issues/9033