### PR TITLE
Add support for WatchProgressRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.9
 	go.etcd.io/etcd/server/v3 v3.5.9
 	google.golang.org/grpc v1.56.3
+	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
 )
 
@@ -90,7 +91,6 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apimachinery v0.25.4 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/main.go
+++ b/main.go
@@ -96,6 +96,12 @@ func main() {
 			Usage:       "Enable net/http/pprof handlers on the metrics bind address. Default is false.",
 			Destination: &metricsConfig.EnableProfiling,
 		},
+		cli.DurationFlag{
+			Name:        "watch-progress-notify-interval",
+			Usage:       "Interval between periodic watch progress notifications. Default is 10m.",
+			Destination: &config.NotifyInterval,
+			Value:       time.Minute * 10,
+		},
 		cli.BoolFlag{Name: "debug"},
 	}
 	app.Action = run

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/k3s-io/kine/pkg/drivers/dqlite"
 	"github.com/k3s-io/kine/pkg/drivers/generic"
@@ -44,6 +45,7 @@ type Config struct {
 	ServerTLSConfig      tls.Config
 	BackendTLSConfig     tls.Config
 	MetricsRegisterer    prometheus.Registerer
+	NotifyInterval       time.Duration
 }
 
 type ETCDConfig struct {
@@ -80,7 +82,7 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	}
 
 	// set up GRPC server and register services
-	b := server.New(backend, endpointScheme(config))
+	b := server.New(backend, endpointScheme(config), config.NotifyInterval)
 	grpcServer, err := grpcServer(config)
 	if err != nil {
 		return ETCDConfig{}, errors.Wrap(err, "creating GRPC server")

--- a/pkg/server/limited.go
+++ b/pkg/server/limited.go
@@ -2,13 +2,15 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
 type LimitedServer struct {
-	backend Backend
-	scheme  string
+	notifyInterval time.Duration
+	backend        Backend
+	scheme         string
 }
 
 func (l *LimitedServer) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"time"
+
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -12,11 +14,12 @@ type KVServerBridge struct {
 	limited *LimitedServer
 }
 
-func New(backend Backend, scheme string) *KVServerBridge {
+func New(backend Backend, scheme string, notifyInterval time.Duration) *KVServerBridge {
 	return &KVServerBridge{
 		limited: &LimitedServer{
-			backend: backend,
-			scheme:  scheme,
+			notifyInterval: notifyInterval,
+			backend:        backend,
+			scheme:         scheme,
 		},
 	}
 }


### PR DESCRIPTION
* Adds support for watch progress requests.
  If all channels are synced, sends the current revision using channel -1. This allows the watch client to determine the datastore's current revision on-demand in between progress report intervals.

  This matches the implementation from upstream etcd: 
  * https://github.com/etcd-io/etcd/blob/v3.5.11/server/mvcc/watchable_store.go#L485-L487
  * https://github.com/etcd-io/etcd/blob/v3.5.11/server/mvcc/watchable_store.go#L500-L504
  For:
  * https://github.com/k3s-io/kine/issues/267
* Make progress report notification interval configurable.
  Required by kubernetes as per https://github.com/kubernetes/kubernetes/issues/122805#issuecomment-1898386268
* Optimize CurrentRevision checks by sharing current revision marker from poll loop
  Progress notifications query the current revision frequently; this can be optimized by exposing the poll loop's current revision once the loop has been started.