### PR TITLE
fixes the incorrect total items count in a paginated list items q…

### DIFF
--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -135,8 +135,8 @@ func (b *Backend) CurrentRevision(ctx context.Context) (int64, error) {
 }
 
 // Count returns an exact count of the number of matching keys and the current revision of the database.
-func (b *Backend) Count(ctx context.Context, prefix string) (int64, int64, error) {
-	count, err := b.kv.Count(ctx, prefix)
+func (b *Backend) Count(ctx context.Context, prefix string, revision int64) (int64, int64, error) {
+	count, err := b.kv.Count(ctx, prefix, revision)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/drivers/nats/backend_test.go
+++ b/pkg/drivers/nats/backend_test.go
@@ -129,14 +129,14 @@ func TestBackend_Create(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
-	srev, count, err := b.Count(ctx, "/")
+	srev, count, err := b.Count(ctx, "/", 0)
 	noErr(t, err)
 	expEqual(t, 4, srev)
 	expEqual(t, 4, count)
 
 	time.Sleep(time.Second)
 
-	srev, count, err = b.Count(ctx, "/")
+	srev, count, err = b.Count(ctx, "/", 0)
 	noErr(t, err)
 	expEqual(t, 4, srev)
 	expEqual(t, 3, count)
@@ -149,7 +149,7 @@ func TestBackend_Create(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
-	srev, count, err = b.Count(ctx, "/")
+	srev, count, err = b.Count(ctx, "/", 0)
 	noErr(t, err)
 	expEqual(t, 6, srev)
 	expEqual(t, 4, count)

--- a/pkg/drivers/nats/logger.go
+++ b/pkg/drivers/nats/logger.go
@@ -81,15 +81,15 @@ func (b *BackendLogger) List(ctx context.Context, prefix, startKey string, limit
 }
 
 // Count returns an exact count of the number of matching keys and the current revision of the database
-func (b *BackendLogger) Count(ctx context.Context, prefix string) (revRet int64, count int64, err error) {
+func (b *BackendLogger) Count(ctx context.Context, prefix string, revision int64) (revRet int64, count int64, err error) {
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
-		fStr := "COUNT %s => rev=%d, count=%d, err=%v, duration=%s"
-		b.logMethod(dur, fStr, prefix, revRet, count, err, dur)
+		fStr := "COUNT %s, rev=%d => rev=%d, count=%d, err=%v, duration=%s"
+		b.logMethod(dur, fStr, prefix, revision, revRet, count, err, dur)
 	}()
 
-	return b.backend.Count(ctx, prefix)
+	return b.backend.Count(ctx, prefix, revision)
 }
 
 func (b *BackendLogger) Update(ctx context.Context, key string, value []byte, revision, lease int64) (revRet int64, kvRet *server.KeyValue, updateRet bool, errRet error) {

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -22,7 +22,7 @@ type Log interface {
 	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeletes bool) (int64, []*server.Event, error)
 	After(ctx context.Context, prefix string, revision, limit int64) (int64, []*server.Event, error)
 	Watch(ctx context.Context, prefix string) <-chan []*server.Event
-	Count(ctx context.Context, prefix string) (int64, int64, error)
+	Count(ctx context.Context, prefix string, revision int64) (int64, int64, error)
 	Append(ctx context.Context, event *server.Event) (int64, error)
 	DbSize(ctx context.Context) (int64, error)
 }
@@ -198,11 +198,11 @@ func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit
 	return rev, kvs, nil
 }
 
-func (l *LogStructured) Count(ctx context.Context, prefix string) (revRet int64, count int64, err error) {
+func (l *LogStructured) Count(ctx context.Context, prefix string, revision int64) (revRet int64, count int64, err error) {
 	defer func() {
-		logrus.Tracef("COUNT %s => rev=%d, count=%d, err=%v", prefix, revRet, count, err)
+		logrus.Tracef("COUNT %s, rev=%d => rev=%d, count=%d, err=%v", prefix, revision, revRet, count, err)
 	}()
-	rev, count, err := l.log.Count(ctx, prefix)
+	rev, count, err := l.log.Count(ctx, prefix, revision)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -524,11 +524,15 @@ func canSkipRevision(rev, skip int64, skipTime time.Time) bool {
 	return rev == skip && time.Since(skipTime) > time.Second
 }
 
-func (s *SQLLog) Count(ctx context.Context, prefix string) (int64, int64, error) {
+func (s *SQLLog) Count(ctx context.Context, prefix string, revision int64) (int64, int64, error) {
 	if strings.HasSuffix(prefix, "/") {
 		prefix += "%"
 	}
-	return s.d.Count(ctx, prefix)
+
+	if revision == 0 {
+		return s.d.CountCurrent(ctx, prefix)
+	}
+	return s.d.Count(ctx, prefix, revision)
 }
 
 func (s *SQLLog) Append(ctx context.Context, event *server.Event) (int64, error) {

--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -53,6 +53,14 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 	if limit > 0 && resp.Count > r.Limit {
 		resp.More = true
 		resp.Kvs = kvs[0 : limit-1]
+
+		// count the actual number of results if there are more items in the db.
+		_, count, err := l.backend.Count(ctx, prefix)
+		if err != nil {
+			return nil, err
+		}
+		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", r.Key, r.RangeEnd, r.Revision, rev, count)
+		resp.Count = count
 	}
 
 	return resp, nil

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -23,7 +23,7 @@ type Backend interface {
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)
 	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
-	Count(ctx context.Context, prefix string) (int64, int64, error)
+	Count(ctx context.Context, prefix string, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
 	Watch(ctx context.Context, key string, revision int64) WatchResult
 	DbSize(ctx context.Context) (int64, error)
@@ -33,7 +33,8 @@ type Backend interface {
 type Dialect interface {
 	ListCurrent(ctx context.Context, prefix string, limit int64, includeDeleted bool) (*sql.Rows, error)
 	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted bool) (*sql.Rows, error)
-	Count(ctx context.Context, prefix string) (int64, int64, error)
+	CountCurrent(ctx context.Context, prefix string) (int64, int64, error)
+	Count(ctx context.Context, prefix string, revision int64) (int64, int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
 	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (int64, error)


### PR DESCRIPTION
When making a list query the returned total matched items count is wrong.

**Steps to replicate:**
create some keys in the database with specific prefix say `/registry` then query with limit clause.

```
kine ❯ etcdctl get --prefix /registry --limit 1 --write-out=json | jq
{
  "header": {
    "revision": 494943
  },
  "kvs": [
    {
      "key": "L3JlZ2lzdHJ5L2hlYWx0aA==",
      "create_revision": 2,
      "mod_revision": 2,
      "value": "eyJoZWFsdGgiOiJ0cnVlIn0="
    }
  ],
  "more": true,
  "count": 2
}
```

the count shows wrong value.



**After this Fix**
```
kine ❯ etcdctl get --prefix /registry --limit 1 --write-out=json | jq
{
  "header": {
    "revision": 495036
  },
  "kvs": [
    {
      "key": "L3JlZ2lzdHJ5L2hlYWx0aA==",
      "create_revision": 2,
      "mod_revision": 2,
      "value": "eyJoZWFsdGgiOiJ0cnVlIn0="
    }
  ],
  "more": true,
  "count": 1842
}
```


