### PR TITLE
feat: compaction support

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	Create(ctx context.Context, key string, value []byte) error
 	Update(ctx context.Context, key string, revision int64, value []byte) error
 	Delete(ctx context.Context, key string, revision int64) error
+	Compact(ctx context.Context, revision int64) (int64, error)
 	Close() error
 }
 
@@ -142,6 +143,11 @@ func (c *client) Delete(ctx context.Context, key string, revision int64) error {
 		return fmt.Errorf("revision %d doesnt match", revision)
 	}
 	return nil
+}
+
+func (c *client) Compact(ctx context.Context, revision int64) (int64, error) {
+	resp, err := c.c.Compact(ctx, revision)
+	return resp.Header.GetRevision(), err
 }
 
 func (c *client) Close() error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -147,7 +147,10 @@ func (c *client) Delete(ctx context.Context, key string, revision int64) error {
 
 func (c *client) Compact(ctx context.Context, revision int64) (int64, error) {
 	resp, err := c.c.Compact(ctx, revision)
-	return resp.Header.GetRevision(), err
+	if resp != nil {
+		return resp.Header.GetRevision(), err
+	}
+	return 0, err
 }
 
 func (c *client) Close() error {

--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -428,7 +428,7 @@ func (b *Backend) Watch(ctx context.Context, prefix string, startRevision int64)
 	}
 }
 
-// Compact is a no-op / not implemented.
+// Compact is a no-op / not implemented. Revision history is managed by the jetstream bucket.
 func (b *Backend) Compact(ctx context.Context, revision int64) (int64, error) {
 	return revision, nil
 }

--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -427,3 +427,8 @@ func (b *Backend) Watch(ctx context.Context, prefix string, startRevision int64)
 		CurrentRevision: rev,
 	}
 }
+
+// Compact is a no-op / not implemented.
+func (b *Backend) Compact(ctx context.Context, revision int64) (int64, error) {
+	return revision, nil
+}

--- a/pkg/drivers/nats/logger.go
+++ b/pkg/drivers/nats/logger.go
@@ -120,3 +120,8 @@ func (b *BackendLogger) DbSize(ctx context.Context) (int64, error) {
 func (b *BackendLogger) CurrentRevision(ctx context.Context) (int64, error) {
 	return b.backend.CurrentRevision(ctx)
 }
+
+// Compact is a no-op / not implemented.
+func (b *BackendLogger) Compact(ctx context.Context, revision int64) (int64, error) {
+	return revision, nil
+}

--- a/pkg/drivers/nats/logger.go
+++ b/pkg/drivers/nats/logger.go
@@ -121,7 +121,7 @@ func (b *BackendLogger) CurrentRevision(ctx context.Context) (int64, error) {
 	return b.backend.CurrentRevision(ctx)
 }
 
-// Compact is a no-op / not implemented.
+// Compact is a no-op / not implemented. Revision history is managed by the jetstream bucket.
 func (b *BackendLogger) Compact(ctx context.Context, revision int64) (int64, error) {
 	return revision, nil
 }

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -25,6 +25,7 @@ type Log interface {
 	Count(ctx context.Context, prefix string, revision int64) (int64, int64, error)
 	Append(ctx context.Context, event *server.Event) (int64, error)
 	DbSize(ctx context.Context) (int64, error)
+	Compact(ctx context.Context, revision int64) (int64, error)
 }
 
 type ttlEventKV struct {
@@ -492,4 +493,8 @@ func (l *LogStructured) DbSize(ctx context.Context) (int64, error) {
 
 func (l *LogStructured) CurrentRevision(ctx context.Context) (int64, error) {
 	return l.log.CurrentRevision(ctx)
+}
+
+func (l *LogStructured) Compact(ctx context.Context, revision int64) (int64, error) {
+	return l.log.Compact(ctx, revision)
 }

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -610,3 +610,7 @@ func safeCompactRev(targetCompactRev int64, currentRev int64) int64 {
 func (s *SQLLog) DbSize(ctx context.Context) (int64, error) {
 	return s.d.GetSize(ctx)
 }
+
+func (s *SQLLog) Compact(ctx context.Context, revision int64) (int64, error) {
+	return s.d.Compact(ctx, revision)
+}

--- a/pkg/server/create.go
+++ b/pkg/server/create.go
@@ -19,7 +19,7 @@ func isCreate(txn *etcdserverpb.TxnRequest) *etcdserverpb.PutRequest {
 	return nil
 }
 
-func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest, txn *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
+func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest) (*etcdserverpb.TxnResponse, error) {
 	if put.IgnoreLease {
 		return nil, unsupported("ignoreLease")
 	} else if put.IgnoreValue {

--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -109,9 +109,9 @@ func (k *KVServerBridge) Txn(ctx context.Context, r *etcdserverpb.TxnRequest) (*
 }
 
 func (k *KVServerBridge) Compact(ctx context.Context, r *etcdserverpb.CompactionRequest) (*etcdserverpb.CompactionResponse, error) {
-	return &etcdserverpb.CompactionResponse{
-		Header: &etcdserverpb.ResponseHeader{
-			Revision: r.Revision,
-		},
-	}, nil
+	res, err := k.limited.Compact(ctx, r)
+	if err != nil {
+		logrus.Errorf("error in compact %s: %v", r, err)
+	}
+	return res, err
 }

--- a/pkg/server/limited.go
+++ b/pkg/server/limited.go
@@ -28,7 +28,7 @@ func txnHeader(rev int64) *etcdserverpb.ResponseHeader {
 
 func (l *LimitedServer) Txn(ctx context.Context, txn *etcdserverpb.TxnRequest) (*etcdserverpb.TxnResponse, error) {
 	if put := isCreate(txn); put != nil {
-		return l.create(ctx, put, txn)
+		return l.create(ctx, put)
 	}
 	if rev, key, ok := isDelete(txn); ok {
 		return l.delete(ctx, key, rev)
@@ -37,7 +37,7 @@ func (l *LimitedServer) Txn(ctx context.Context, txn *etcdserverpb.TxnRequest) (
 		return l.update(ctx, rev, key, value, lease)
 	}
 	if isCompact(txn) {
-		return l.compact(ctx)
+		return l.compact()
 	}
 	return nil, ErrNotSupported
 }

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -28,6 +28,7 @@ type Backend interface {
 	Watch(ctx context.Context, key string, revision int64) WatchResult
 	DbSize(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
+	Compact(ctx context.Context, revision int64) (int64, error)
 }
 
 type Dialect interface {


### PR DESCRIPTION
This PR adds support for gRPC compaction requests for all backends. For NATS, compaction is handled by Jetstream and the bucket's `History` setting, so compaction requests are no-ops.

Additionally, unused params were removed from the LimitedServer's `compact` and `create` methods.

Given that the default compaction interval of 5min is not exposed as a configuration option, it can be useful to be able to trigger ad hoc compactions, which partially addresses #230.

### Test code
```golang
package main

import (
	"context"
	"fmt"
	"os"
	"strconv"

	"go.etcd.io/etcd/etcdserver/etcdserverpb"
	"google.golang.org/grpc"
	"google.golang.org/grpc/credentials/insecure"
)

func main() {
	compactRevision := os.Args[1]
	cr, err := strconv.ParseInt(compactRevision, 10, 64)
	if err != nil {
		panic(err)
	}

	conn, err := grpc.Dial("localhost:2379",
		grpc.WithTransportCredentials(insecure.NewCredentials()),
	)
	if err != nil {
		panic(err)
	}
	defer conn.Close()
	fmt.Println("Connected to kine")

	r := &etcdserverpb.CompactionRequest{
		Revision: cr,
	}
	fmt.Println("Triggering compaction", "revision", r.Revision)

	c := etcdserverpb.NewKVClient(conn)
	resp, err := c.Compact(context.Background(), r)
	if err != nil {
		panic(err)
	}

	fmt.Println("Received compaction response with revision", resp.Header.Revision)
}
```

### Sample output
```
root@tyler-k11-8277bf2c:/home/demo# ./kine-compact 1755748
Connected to kine
Triggering compaction revision 1755748
Received compaction response with revision 1002
```