### PR TITLE
Add a if to not send logs when context is canceled

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -2,6 +2,7 @@ package logstructured
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -446,7 +447,9 @@ func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64
 
 	rev, kvs, err := l.log.After(ctx, prefix, revision, 0)
 	if err != nil {
-		logrus.Errorf("Failed to list %s for revision %d: %v", prefix, revision, err)
+		if !errors.Is(err, context.Canceled) {
+			logrus.Errorf("Failed to list %s for revision %d: %v", prefix, revision, err)
+		}
 		if err == server.ErrCompacted {
 			compact, _ := l.log.CompactRevision(ctx)
 			wr.CompactRevision = compact


### PR DESCRIPTION
- This error log appear when k3s closes the first kine client after the bootstrap when using tls, so we do not need the log at this moment.