### PR TITLE
Add a error verification when failed list is from context canceled

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -432,7 +432,9 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 
 		rows, err := s.d.After(s.ctx, "%", s.currentRev, pollBatchSize)
 		if err != nil {
-			logrus.Errorf("fail to list latest changes: %v", err)
+			if !errors.Is(err, context.Canceled) {
+				logrus.Errorf("fail to list latest changes: %v", err)
+			}
 			continue
 		}
 


### PR DESCRIPTION
- When testing kine with k3s/rke2 I discovered that this log appears sometimes when the context is canceled quickly