### PR TITLE
feat: support RISC-V 64

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -10,6 +10,8 @@ mkdir -p bin
 if [ ${ARCH} = armv7l ] || [ ${ARCH} = arm ]; then
     export GOARCH="arm"
     export GOARM="7"
+elif [ ${ARCH} = riscv64 ]; then
+    export GOARCH="riscv64"
 fi
 
 if [ "$(uname)" = "Linux" ]; then


### PR DESCRIPTION
I do not fully understand how the Dapper scripts work, but build works, so should be good?

How I tested it:

```sh
make ARCH=riscv64
docker run \
    --rm --interactive --tty \
    --volume=./bin/:/mnt/bin \
    --platform=linux/riscv64 \
    riscv64/busybox \
        /mnt/bin/kine
```

Closes #296 