### PR TITLE
Add support for TLS skip verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,23 @@ func main() {
 			Destination: &config.BackendTLSConfig.CertFile,
 		},
 		&cli.StringFlag{
+			Name:        "key-file",
+			Usage:       "Key file for DB connection",
+			Destination: &config.BackendTLSConfig.KeyFile,
+		},
+		&cli.BoolFlag{
+			Name:        "skip-verify",
+			Usage:       "Whether the TLS client should verify the server certificate.",
+			Destination: &config.BackendTLSConfig.SkipVerify,
+			Value:       false,
+		},
+		&cli.StringFlag{
+			Name:        "metrics-bind-address",
+			Usage:       "The address the metric endpoint binds to. Default :8080, set 0 to disable metrics serving.",
+			Destination: &metricsConfig.ServerAddress,
+			Value:       ":8080",
+		},
+		&cli.StringFlag{
 			Name:        "server-cert-file",
 			Usage:       "Certificate for etcd connection",
 			Destination: &config.ServerTLSConfig.CertFile,
@@ -55,12 +72,6 @@ func main() {
 			Name:        "server-key-file",
 			Usage:       "Key file for etcd connection",
 			Destination: &config.ServerTLSConfig.KeyFile,
-		},
-		&cli.BoolFlag{
-			Name:        "skip-verify",
-			Usage:       "Whether the TLS client should verify the server certificate.",
-			Destination: &config.BackendTLSConfig.SkipVerify,
-			Value:       false,
 		},
 		&cli.IntFlag{
 			Name:        "datastore-max-idle-connections",
@@ -79,17 +90,6 @@ func main() {
 			Usage:       "Maximum amount of time a connection may be reused. If value <= 0, then there is no limit.",
 			Destination: &config.ConnectionPoolConfig.MaxLifetime,
 			Value:       0,
-		},
-		&cli.StringFlag{
-			Name:        "key-file",
-			Usage:       "Key file for DB connection",
-			Destination: &config.BackendTLSConfig.KeyFile,
-		},
-		&cli.StringFlag{
-			Name:        "metrics-bind-address",
-			Usage:       "The address the metric endpoint binds to. Default :8080, set 0 to disable metrics serving.",
-			Destination: &metricsConfig.ServerAddress,
-			Value:       ":8080",
 		},
 		&cli.DurationFlag{
 			Name:        "slow-sql-threshold",

--- a/main.go
+++ b/main.go
@@ -56,6 +56,12 @@ func main() {
 			Usage:       "Key file for etcd connection",
 			Destination: &config.ServerTLSConfig.KeyFile,
 		},
+		&cli.BoolFlag{
+			Name:        "skip-verify",
+			Usage:       "Whether the TLS client should verify the server certificate.",
+			Destination: &config.BackendTLSConfig.SkipVerify,
+			Value:       false,
+		},
 		&cli.IntFlag{
 			Name:        "datastore-max-idle-connections",
 			Usage:       "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.",

--- a/pkg/tls/config.go
+++ b/pkg/tls/config.go
@@ -7,9 +7,10 @@ import (
 )
 
 type Config struct {
-	CAFile   string
-	CertFile string
-	KeyFile  string
+	CAFile     string
+	CertFile   string
+	KeyFile    string
+	SkipVerify bool
 }
 
 func (c Config) ClientConfig() (*tls.Config, error) {
@@ -18,9 +19,10 @@ func (c Config) ClientConfig() (*tls.Config, error) {
 	}
 
 	info := &transport.TLSInfo{
-		CertFile:      c.CertFile,
-		KeyFile:       c.KeyFile,
-		TrustedCAFile: c.CAFile,
+		CertFile:           c.CertFile,
+		KeyFile:            c.KeyFile,
+		TrustedCAFile:      c.CAFile,
+		InsecureSkipVerify: c.SkipVerify,
 	}
 	tlsConfig, err := info.ClientConfig()
 	if err != nil {


### PR DESCRIPTION
As mentioned here: https://github.com/k3s-io/k3s/issues/1093 , it is not possible to skip TLS verification. This patch adds support for skipping it. Not sure if it's the correct approach tho :)