### PR TITLE
fix: only log slow sql query parameters if trace logging is enabled

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -43,6 +43,10 @@ func ObserveSQL(start time.Time, errCode string, sql util.Stripped, args ...inte
 	duration := time.Since(start)
 	SQLTime.WithLabelValues(errCode).Observe(duration.Seconds())
 	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold {
-		logrus.Infof("Slow SQL (started: %v) (total time: %v): %s : %v", start, duration, sql, args)
+		if logrus.GetLevel() == logrus.TraceLevel {
+			logrus.Tracef("Slow SQL (started: %v) (total time: %v): %s : %v", start, duration, sql, args)
+		} else {
+			logrus.Infof("Slow SQL (started: %v) (total time: %v): %s", start, duration, sql)
+		}
 	}
 }


### PR DESCRIPTION
This corrects https://github.com/k3s-io/kine/issues/305 by only dumping the sql query parameters in the slow sql log if the log level is set to trace.