### PR TITLE
Return an emulated etcd version in the status endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,15 +98,15 @@ func main() {
 		},
 		&cli.DurationFlag{
 			Name:        "watch-progress-notify-interval",
-			Usage:       "Interval between periodic watch progress notifications. Default is 10m.",
+			Usage:       "Interval between periodic watch progress notifications. Default is 5s to ensure support for watch progress notifications.",
 			Destination: &config.NotifyInterval,
-			Value:       time.Minute * 10,
+			Value:       time.Second * 5,
 		},
 		&cli.StringFlag{
 			Name:        "emulated-etcd-version",
-			Usage:       "The emulated etcd version to return on a call to the status endpoint. Defaults to 3.4.31 which is the least version that support Kubernetes watch progress feature.",
+			Usage:       "The emulated etcd version to return on a call to the status endpoint. Defaults to 3.5.13, in order to indicate support for watch progress notifications.",
 			Destination: &config.EmulatedETCDVersion,
-			Value:       "3.4.31",
+			Value:       "3.5.13",
 		},
 		&cli.BoolFlag{Name: "debug"},
 	}

--- a/main.go
+++ b/main.go
@@ -102,6 +102,12 @@ func main() {
 			Destination: &config.NotifyInterval,
 			Value:       time.Minute * 10,
 		},
+		&cli.StringFlag{
+			Name:        "emulated-etcd-version",
+			Usage:       "The emulated etcd version to return on a call to the status endpoint. Defaults to 3.4.31 which is the least version that support Kubernetes watch progress feature.",
+			Destination: &config.EmulatedETCDVersion,
+			Value:       "3.4.31",
+		},
 		&cli.BoolFlag{Name: "debug"},
 	}
 	app.Action = run

--- a/pkg/drivers/nats/new.go
+++ b/pkg/drivers/nats/new.go
@@ -224,7 +224,7 @@ func getOrCreateBucket(ctx context.Context, js jetstream.JetStream, config *Conf
 
 		// Check for temporary JetStream errors when the cluster is unhealthy and retry.
 		if jsClusterNotAvailErr.Is(err) || jsNoSuitablePeersErr.Is(err) {
-			logrus.Warnf(err.Error())
+			logrus.Warn(err.Error())
 			time.Sleep(time.Second)
 			continue
 		}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -46,6 +46,7 @@ type Config struct {
 	BackendTLSConfig     tls.Config
 	MetricsRegisterer    prometheus.Registerer
 	NotifyInterval       time.Duration
+	EmulatedETCDVersion  string
 }
 
 type ETCDConfig struct {
@@ -82,7 +83,7 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	}
 
 	// set up GRPC server and register services
-	b := server.New(backend, endpointScheme(config), config.NotifyInterval)
+	b := server.New(backend, endpointScheme(config), config.NotifyInterval, config.EmulatedETCDVersion)
 	grpcServer, err := grpcServer(config)
 	if err != nil {
 		return ETCDConfig{}, errors.Wrap(err, "creating GRPC server")

--- a/pkg/server/maintenance.go
+++ b/pkg/server/maintenance.go
@@ -22,7 +22,7 @@ func (s *KVServerBridge) Status(ctx context.Context, r *etcdserverpb.StatusReque
 	return &etcdserverpb.StatusResponse{
 		Header:  &etcdserverpb.ResponseHeader{},
 		DbSize:  size,
-		Version: s.EmulatedETCDVersion,
+		Version: s.emulatedETCDVersion,
 	}, nil
 }
 

--- a/pkg/server/maintenance.go
+++ b/pkg/server/maintenance.go
@@ -20,8 +20,9 @@ func (s *KVServerBridge) Status(ctx context.Context, r *etcdserverpb.StatusReque
 		return nil, err
 	}
 	return &etcdserverpb.StatusResponse{
-		Header: &etcdserverpb.ResponseHeader{},
-		DbSize: size,
+		Header:  &etcdserverpb.ResponseHeader{},
+		DbSize:  size,
+		Version: s.EmulatedETCDVersion,
 	}, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,18 +11,18 @@ import (
 )
 
 type KVServerBridge struct {
+	emulatedETCDVersion string
 	limited             *LimitedServer
-	EmulatedETCDVersion string
 }
 
 func New(backend Backend, scheme string, notifyInterval time.Duration, emulatedETCDVersion string) *KVServerBridge {
 	return &KVServerBridge{
+		emulatedETCDVersion: emulatedETCDVersion,
 		limited: &LimitedServer{
 			notifyInterval: notifyInterval,
 			backend:        backend,
 			scheme:         scheme,
 		},
-		EmulatedETCDVersion: emulatedETCDVersion,
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,16 +11,18 @@ import (
 )
 
 type KVServerBridge struct {
-	limited *LimitedServer
+	limited             *LimitedServer
+	EmulatedETCDVersion string
 }
 
-func New(backend Backend, scheme string, notifyInterval time.Duration) *KVServerBridge {
+func New(backend Backend, scheme string, notifyInterval time.Duration, emulatedETCDVersion string) *KVServerBridge {
 	return &KVServerBridge{
 		limited: &LimitedServer{
 			notifyInterval: notifyInterval,
 			backend:        backend,
 			scheme:         scheme,
 		},
+		EmulatedETCDVersion: emulatedETCDVersion,
 	}
 }
 


### PR DESCRIPTION
Fixes #315 

See https://github.com/kubernetes/kubernetes/blob/beb696c2c9467dbc44cbaf35c5a4a3daf0321db3/staging/src/k8s.io/apiserver/pkg/storage/feature/feature_support_checker.go#L157

Which expects that the etcd status endpoint return a version. This returns a default version allowing users to override it if necessary.
