### PR TITLE
Dramatically improve postgresql performance

### DIFF
--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -48,6 +48,9 @@ var (
 	}
 	schemaMigrations = []string{
 		`ALTER TABLE kine MODIFY COLUMN id BIGINT UNSIGNED AUTO_INCREMENT NOT NULL UNIQUE, MODIFY COLUMN create_revision BIGINT UNSIGNED, MODIFY COLUMN prev_revision BIGINT UNSIGNED`,
+		// Creating an empty migration to ensure that postgresql and mysql migrations match up
+		// with each other for a give value of KINE_SCHEMA_MIGRATION env var
+		``,
 	}
 	createDB = "CREATE DATABASE IF NOT EXISTS "
 )
@@ -147,6 +150,9 @@ func setup(db *sql.DB) error {
 	for i, stmt := range schemaMigrations {
 		if i >= int(schemaVersion) {
 			break
+		}
+		if stmt == "" {
+			continue
 		}
 		logrus.Tracef("SETUP EXEC MIGRATION %d: %v", i, util.Stripped(stmt))
 		if _, err := db.Exec(stmt); err != nil {

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -180,6 +180,9 @@ func setup(db *sql.DB) error {
 		if i >= int(schemaVersion) {
 			break
 		}
+		if stmt == "" {
+			continue
+		}
 		logrus.Tracef("SETUP EXEC MIGRATION %d: %v", i, util.Stripped(stmt))
 		if _, err := db.Exec(stmt); err != nil {
 			return err

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -54,7 +54,7 @@ var (
 		`ALTER TABLE kine ALTER COLUMN id SET DATA TYPE BIGINT, ALTER COLUMN create_revision SET DATA TYPE BIGINT, ALTER COLUMN prev_revision SET DATA TYPE BIGINT; ALTER SEQUENCE kine_id_seq AS BIGINT`,
 		// It is important to set the collation to "C" to ensure that LIKE and COMPARISON
 		// queries use the index.
-		`ALTER TABLE kine ALTER COLUMN name SET DATA TYPE TEXT USING name::TEXT COLLATE "C"`,
+		`ALTER TABLE kine ALTER COLUMN name SET DATA TYPE TEXT COLLATE "C" USING name::TEXT COLLATE "C"`,
 	}
 	createDB = "CREATE DATABASE "
 )


### PR DESCRIPTION
## Contributors

Co-Authored by @adriangonz who paired with me on this change and also tested/benched all the changes 🎉 

This builds on top of the great work done in #151 by @moio (included as a co-author on this PR since it builds on top of the ideas introduced in the said PR)

## Benchmarks

### For a paginanted API Server list query (which uses CountRevision and List with a filter query) we were able to see speed-ups **from 70+ seconds to 2 seconds** (35x speed-up) for a kine DB with 1M+ resources that match the list query. The speed-up might be larger for larger kine DBs.

Individually we were able to bring the count query down to 1.5s from ~40s and the list query down to 0.5s from ~30s on our test bench.

This is fairly significant as it makes kine usable/scalable at such high volume of objects.

Without the above changes we would usually see timeouts and context cancelled errors most of the times.


## Changes
### Datatype Change

In Postgres, `text` tends to give better performance and use less space. When using `varchar`,

 - Values get padded to the max size (whereas `text` values can be sparse).
 - Each update / insert has an extra check to validate the length of the value.
 - The query planner casts `varchar` entries to `text` anyway.
 
The main benefit provided by `varchar` is making sure that all values are shorter than N characters. However, in the case of `kine`, that's already validated upstream by `kube-apiserver`.

See the [Postgres docs](https://www.postgresql.org/docs/current/datatype-character.html) for more info. 

### Collate Change

When using the `C.UTF-8` locale (which comes as default on many Postgres setups), indices working on `text` (or `varchar`) columns can't be used for `LIKE` operations. The workaround in this case is to create the index with a `text_pattern_ops` operator. However, the resulting index can't then be used for `<` / `>` queries. It's possible to work around this second issue by creating a *second index* that uses the default operator for the `text` column, however that then introduces unnecessary overhead.

Instead, a simpler fix is to change the collation of the `name` column to use the `C` locale. This means that the strings saved in this column are treated as ASCII values (i.e. each character is a byte), which in turn lets queries use indices for all operations. Since the values in the `name` column will be a concatenation of DNS-like segments, we shouldn't get any UTF-8 values there. 

See the [Postgres docs on text indices](https://www.postgresql.org/docs/current/indexes-opclass.html) for more info. This [SO answer](https://stackoverflow.com/a/13452528) a lot of useful context around this issue.

> Note: This might also explain the past MySQL v/s PostgreSQL differences that have been observed in kine as MySQL schema stores the name as an ASCII column. https://github.com/k3s-io/kine/blob/70a99f8773aef5f9c3b78f402887d26965db0375/pkg/drivers/mysql/mysql.go#L33

### Query changes

Most of the original List/Count queries are derived from https://github.com/k3s-io/kine/pull/151 and have been adapted to support the new CountCurrent and CountRevision. There were also some minor bugs in the original PR WRT to the order of filter queries which has been fixed.

Even without the query changes, the PR achieves a significant speed up with the existing queries as all of them start using the indices for `name` in the `LIKE` and `>` queries.


