### PR TITLE
ci: add gomod to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,13 @@ updates:
       - "k3s-io/k3s-dev"
     schedule:
       interval: "weekly"
+
+  # Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "kind/dependabot"
+    reviewers:
+      - "k3s-io/k3s-dev"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Purpose

This change allows Dependabot to automatically check for updates to Go module dependencies and create pull requests for those updates.