### PR TITLE
ci: increase open PRs for gomod on dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,7 @@ updates:
 
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"
+    open-pull-requests-limit: 15
     directory: "/"
     labels:
       - "kind/dependabot"


### PR DESCRIPTION
The default limit is 5. Increasing it to 15 to have more visibility about Go packages upgradability.