### PR TITLE
Dependabot: Group common go dependencies, ignore NATS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,12 @@ updates:
       - "k3s-io/k3s-dev"
     schedule:
       interval: "weekly"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - k8s.io/*
+      etcd-dependencies:
+        patterns:
+          - go.etcd.io/*
+    ignore:
+      - dependency-name: "github.com/nats-io/nats-server/v2"


### PR DESCRIPTION
Group etcd and k8s bumps together to reduce PR spam. Have dependabot ignore NATs bumps as those require manual review and implementation by the NATs contributors.