### PR TITLE
Fix rolling compact

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -156,17 +156,17 @@ outer:
 				metrics.CompactTotal.WithLabelValues(metrics.ResultError).Inc()
 				continue outer
 			}
-
-			// Record progress for the outer loop
-			compactRev = compactedRev
-			targetCompactRev = currentRev
-
-			metrics.CompactTotal.WithLabelValues(metrics.ResultSuccess).Inc()
 		}
 
 		if err := s.postCompact(); err != nil {
 			logrus.Errorf("Post-compact operations failed: %v", err)
 		}
+
+		// Record the final results for the outer loop
+		compactRev = compactedRev
+		targetCompactRev = currentRev
+
+		metrics.CompactTotal.WithLabelValues(metrics.ResultSuccess).Inc()
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/k3s-io/kine/issues/363

Undo the change from #360 and fix things the right way. That worked, but had the unfortunate side effect of moving the compact target forward within the inner loop. This whole thing can be done better by simplifying the error handling.

* Revert "Record compact progress and metrics per iteration"
    This reverts commit aa4f2a7c621b64aba27c6b1298c0481e0c0018bf.
* Simplify compact loop error handling
    Rather than restarting the outer loop on unhandled error, simmply break out of the inner loop on any error. We always want to update the compact and target rev, and do post-compact operations - so the only thing we really need to check the error for is logging and metrics.