### PR TITLE
fix: close mysql connection after create database

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -406,6 +406,7 @@ func (d *Generic) IsFill(key string) bool {
 	return strings.HasPrefix(key, "gap-")
 }
 
+//nolint:revive
 func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (id int64, err error) {
 	if d.TranslateErr != nil {
 		defer func() {

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -176,6 +176,7 @@ func createDBIfNotExist(dataSourceName string) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 
 	var exists bool
 	err = db.QueryRow("SELECT 1 FROM information_schema.SCHEMATA WHERE schema_name = ?", dbName).Scan(&exists)
@@ -195,6 +196,7 @@ func createDBIfNotExist(dataSourceName string) error {
 			if err != nil {
 				return err
 			}
+			defer db.Close()
 			if _, err = db.Exec(stmt); err != nil {
 				return err
 			}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -38,6 +38,7 @@ type Dialect interface {
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
+	//nolint:revive
 	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (int64, error)
 	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
 	DeleteRevision(ctx context.Context, revision int64) error


### PR DESCRIPTION
One problem we encountered when using Kine with the MySQL driver is that it uses an unexpected high amount of database connections, even after setting the flag `--datastore-max-open-connections` to a small number. 

We investigated and found out that during the `createDBIfNotExist` function two database connections are created as well that are never closed. For the PostgreSQL driver the connection is closed as expected:
https://github.com/k3s-io/kine/blob/133503d8acbf5979279e32b5a1ff28882c70212a/pkg/drivers/pgsql/pgsql.go#L223

For the MySQL driver, these close after creation defers are missing and hence the connections stay open all the time. This PR adds two lines to close the database connections as expected after making sure the database exists in the MySQL server.

EDIT: Not sure why the drone ci build is failing, but it seems unrelated to this change