### PR TITLE
fix: canceled should always be set to true when cancel a watch request

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -437,7 +437,7 @@ func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64
 				wr.CompactRevision = compact
 				wr.CurrentRevision = rev
 			} else {
-				errc <- errors.New("failed to execute query in database")
+				errc <- server.ErrGRPCUnhealthy
 			}
 		}
 		cancel()

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -425,17 +425,20 @@ func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64
 	}
 
 	result := make(chan []*server.Event, 100)
-	wr := server.WatchResult{Events: result}
+	errc := make(chan error, 1)
+	wr := server.WatchResult{Events: result, Errorc: errc}
 
 	rev, kvs, err := l.log.After(ctx, prefix, revision, 0)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
 			logrus.Errorf("Failed to list %s for revision %d: %v", prefix, revision, err)
-		}
-		if err == server.ErrCompacted {
-			compact, _ := l.log.CompactRevision(ctx)
-			wr.CompactRevision = compact
-			wr.CurrentRevision = rev
+			if err == server.ErrCompacted {
+				compact, _ := l.log.CompactRevision(ctx)
+				wr.CompactRevision = compact
+				wr.CurrentRevision = rev
+			} else {
+				errc <- errors.New("failed to execute query in database")
+			}
 		}
 		cancel()
 	}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -12,9 +12,10 @@ import (
 var (
 	ErrNotSupported = status.New(codes.InvalidArgument, "etcdserver: unsupported operations in txn request").Err()
 
-	ErrKeyExists = rpctypes.ErrGRPCDuplicateKey
-	ErrCompacted = rpctypes.ErrGRPCCompacted
-	ErrFutureRev = rpctypes.ErrGRPCFutureRev
+	ErrKeyExists     = rpctypes.ErrGRPCDuplicateKey
+	ErrCompacted     = rpctypes.ErrGRPCCompacted
+	ErrFutureRev     = rpctypes.ErrGRPCFutureRev
+	ErrGRPCUnhealthy = rpctypes.ErrGRPCUnhealthy
 )
 
 type Backend interface {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -85,6 +85,7 @@ type WatchResult struct {
 	CurrentRevision int64
 	CompactRevision int64
 	Events          <-chan []*Event
+	Errorc          <-chan error
 }
 
 func unsupported(field string) error {

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -219,7 +219,7 @@ func (w *watcher) Cancel(watchID, revision, compactRev int64, err error) {
 
 	serr := w.server.Send(&etcdserverpb.WatchResponse{
 		Header:          txnHeader(revision),
-		Canceled:        err != nil,
+		Canceled:        true,
 		CancelReason:    reason,
 		WatchId:         watchID,
 		CompactRevision: compactRev,

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -172,7 +172,12 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 			}
 		}
 
-		w.Cancel(id, 0, 0, nil)
+		select {
+		case err := <-wr.Errorc:
+			w.Cancel(id, 0, 0, err)
+		default:
+			w.Cancel(id, 0, 0, nil)
+		}
 		logrus.Tracef("WATCH CLOSE id=%d, key=%s", id, key)
 	}()
 }


### PR DESCRIPTION
Anytime the server attempts to cancel a watch request, it should set the `canceled` field to true, regardless of whether `err` is empty or not. Let `err` only affect the `reason` field.