### PR TITLE
Update all testing DBs, remove EOL versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV SRC_DIR=/go/src/github.com/k3s-io/kine
 WORKDIR ${SRC_DIR}/
 
 # Validate needs everything in the project, so we separate it out for better caching
-FROM infra as validate
+FROM infra AS validate
 ARG SKIP_VALIDATE
 ENV SKIP_VALIDATE=${SKIP_VALIDATE}
 COPY . .
@@ -41,6 +41,6 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
     ./scripts/build
 
-FROM scratch as binary
+FROM scratch AS binary
 ENV SRC_DIR=/go/src/github.com/k3s-io/kine
 COPY --from=build ${SRC_DIR}/bin /bin

--- a/scripts/test-run-cockroachdb
+++ b/scripts/test-run-cockroachdb
@@ -28,9 +28,8 @@ start-test() {
 export -f start-test
 
 VERSION_LIST="\
-    cockroachdb v20.2
-    cockroachdb v20.1
-    cockroachdb v19.2"
+    cockroachdb v24.3
+    cockroachdb v24.1"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=POSTGRES_PASSWORD DB_IMAGE=docker.io/$ENGINE/cockroach:latest-$VERSION DB_ARGS="start-single-node --insecure" run-test

--- a/scripts/test-run-mysql
+++ b/scripts/test-run-mysql
@@ -5,11 +5,17 @@ start-test() {
     local port=$(cat $TEST_DIR/databases/*/metadata/port)
     local pass=$(cat $TEST_DIR/databases/*/metadata/password)
     local image=$(cat $TEST_DIR/databases/*/metadata/image)
+    # Starting with mariadb 11, you have to call to mariadb instead of mysql
+    if [[ $image == *mariadb* ]]; then
+       db_type="mariadb"
+    else
+       db_type="mysql"
+    fi
     DB_CONNECTION_TEST="
         docker run --rm
         --name connection-test
         $image
-        mysql
+        $db_type
           --host=$ip
           --port=$port
           --user=root
@@ -27,7 +33,7 @@ VERSION_LIST="\
     mysql 8.0
     mariadb 11.4
     mariadb 10.11
-    mariadb 10.5"
+    mariadb 10.6"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=MYSQL_ROOT_PASSWORD DB_IMAGE=docker.io/library/$ENGINE:$VERSION run-test

--- a/scripts/test-run-mysql
+++ b/scripts/test-run-mysql
@@ -23,11 +23,11 @@ start-test() {
 export -f start-test
 
 VERSION_LIST="\
+    mysql 8.4
     mysql 8.0
-    mysql 5.7
+    mariadb 11.4
     mariadb 10.11
-    mariadb 10.5
-    mariadb 10.4"
+    mariadb 10.5"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=MYSQL_ROOT_PASSWORD DB_IMAGE=docker.io/library/$ENGINE:$VERSION run-test

--- a/scripts/test-run-nats
+++ b/scripts/test-run-nats
@@ -16,7 +16,7 @@ export -f start-test
 # test minimum supported version and most recent version of NATS
 VERSION_LIST="\
     nats 2.9.25
-    nats 2.10.12"
+    nats 2.10.23"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=NATS_JS_PASSWORD DB_ARGS="-js" DB_IMAGE=docker.io/library/$ENGINE:$VERSION run-test

--- a/scripts/test-run-postgres
+++ b/scripts/test-run-postgres
@@ -23,10 +23,10 @@ start-test() {
 export -f start-test
 
 VERSION_LIST="\
-    postgres 15.4
-    postgres 14.9
-    postgres 13.12
-    postgres 12.16"
+    postgres 17
+    postgres 16
+    postgres 15
+    postgres 14"
 
 while read ENGINE VERSION; do
     LABEL=$ENGINE-$VERSION DB_PASSWORD_ENV=POSTGRES_PASSWORD DB_IMAGE=docker.io/library/$ENGINE:$VERSION run-test


### PR DESCRIPTION
- Update all the various DB we test, remove EOL versions.
- Reduce number of cockroachdb versions tested from 3 to 2. This DB takes significantly longer than other DBs to test. 