### PR TITLE
Git ignore debug files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ dist/
 
 # dapper binaries
 .dapper
+
+# Debug builds
+__debug_*


### PR DESCRIPTION
I think it makes things easier if temporary debug related builds are ignored in git.