### PR TITLE
Fix compact rev sql on case of missing

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -35,7 +35,7 @@ var (
 		FROM kine AS rkv`
 
 	compactRevSQL = `
-		SELECT MAX(crkv.prev_revision) AS prev_revision
+		SELECT COALESCE(MAX(crkv.prev_revision), 0) AS prev_revision
 		FROM kine AS crkv
 		WHERE crkv.name = 'compact_rev_key'`
 


### PR DESCRIPTION
There is a very little chance that `compactRevSQL` is returning an empty result, which breaks other query executions. Coalesce ensures the query always returns a number.