### PR TITLE
Fix watch event on case of delete

### DIFF
--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -71,7 +71,7 @@ func toKVs(kvs ...*KeyValue) []*mvccpb.KeyValue {
 
 	ret := make([]*mvccpb.KeyValue, 0, len(kvs))
 	for _, kv := range kvs {
-		newKV := toKV(kv)
+		newKV := toKV(kv, nil)
 		if newKV != nil {
 			ret = append(ret, newKV)
 		}
@@ -79,9 +79,9 @@ func toKVs(kvs ...*KeyValue) []*mvccpb.KeyValue {
 	return ret
 }
 
-func toKV(kv *KeyValue) *mvccpb.KeyValue {
+func toKV(kv *KeyValue, defaultValue *mvccpb.KeyValue) *mvccpb.KeyValue {
 	if kv == nil {
-		return nil
+		return defaultValue
 	}
 	return &mvccpb.KeyValue{
 		Key:            []byte(kv.Key),

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -191,12 +191,19 @@ func toEvents(events ...*Event) []*mvccpb.Event {
 }
 
 func toEvent(event *Event) *mvccpb.Event {
+	emptyEvent := &mvccpb.KeyValue{}
+
 	e := &mvccpb.Event{
-		Kv:     toKV(event.KV),
-		PrevKv: toKV(event.PrevKV),
+		Kv:     toKV(event.KV, emptyEvent),
+		PrevKv: toKV(event.PrevKV, emptyEvent),
 	}
 	if event.Delete {
 		e.Type = mvccpb.DELETE
+		if e.PrevKv.ModRevision == 0 {
+			e.PrevKv = toKV(event.KV, emptyEvent)
+		}
+		e.Kv.Value = nil
+		e.PrevKv.Key = e.Kv.Key
 	} else {
 		e.Type = mvccpb.PUT
 	}


### PR DESCRIPTION
This change targets two small but significant issues. I discovered this by running wide variety of Kubernetes e2e tests and dag into cache how it works.
- Kubernetes doesn't like `nil` `Kv` or `PreKv`, except for deletion where it is mandatory to be `nil`
- In case of deletion it is looking for `PrevKv`, but log structured sends `Kv`. I know it is possible to fix this at `logstructured.go` but in this way Kine should guarantee the right behavior without depending on plugin correctness.

WDYT?