### PR TITLE
Introduce max items to list

### DIFF
--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -3,12 +3,15 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
+
+const maxItems = int64(10000)
 
 func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {
 	if len(r.RangeEnd) == 0 {
@@ -33,9 +36,10 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 	}
 
 	limit := r.Limit
-	if limit > 0 {
-		limit++
+	if limit == 0 {
+		limit = maxItems
 	}
+	limit++
 
 	rev, kvs, err := l.backend.List(ctx, prefix, start, limit, revision)
 	logrus.Tracef("LIST key=%s, end=%s, revision=%d, currentRev=%d count=%d, limit=%d", r.Key, r.RangeEnd, revision, rev, len(kvs), r.Limit)
@@ -46,7 +50,7 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 	}
 
 	// if the number of items returned exceeds the limit, count the keys remaining that follow the start key
-	if limit > 0 && resp.Count > r.Limit {
+	if resp.Count > limit-1 {
 		resp.More = true
 		resp.Kvs = kvs[0 : limit-1]
 
@@ -57,6 +61,10 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		rev, resp.Count, err = l.backend.Count(ctx, prefix, start, revision)
 		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", r.Key, r.RangeEnd, revision, rev, resp.Count)
 		resp.Header = txnHeader(rev)
+
+		if err == nil && resp.Count > maxItems && (r.Limit == 0 || r.Limit > maxItems) && prefix == start {
+			return nil, errors.New("dataset size exceeds the allowed limit, please use limit or rage end to reduce the number of items")
+		}
 	}
 
 	return resp, err


### PR DESCRIPTION
Fetching more than 10000 records from the db should make Kubernetes unresponsive. This change prevents Kine users to shoot themself in the feet. At some places Kubernetes also uses `10000` as the maximum number of items to fetch in once.

WDYT?