### PR TITLE
Fix builds with CGO_ENABLED=0

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -17,3 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Go Unit Tests
       run: go test -cover -tags=test ./...
+    - name: Go Unit Tests (nocgo)
+      run: go test -cover -tags=test ./...
+      env:
+        CGO_ENABLED: "0"

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -15,11 +15,11 @@ import (
 
 var errNoCgo = errors.New("this binary is built without CGO, sqlite is disabled")
 
-func New(ctx context.Context, cfg drivers.Config) (bool, server.Backend, error) {
+func New(_ context.Context, _ *drivers.Config) (bool, server.Backend, error) {
 	return false, nil, errNoCgo
 }
 
-func NewVariant(driverName, cfg drivers.Config) (server.Backend, *generic.Generic, error) {
+func NewVariant(_ context.Context, _ string, cfg *drivers.Config) (server.Backend, *generic.Generic, error) {
 	return nil, nil, errNoCgo
 }
 
@@ -28,6 +28,6 @@ func setup(db *sql.DB) error {
 }
 
 func init() {
-	generic.RegisterDriver("sqlite", New)
-	generic.SetDefaultDriver("sqlite")
+	drivers.Register("sqlite", New)
+	drivers.SetDefault("sqlite")
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -53,7 +53,14 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	})
 
 	if err != nil {
-		return ETCDConfig{}, errors.Wrap(err, "building kine")
+		// Don't print the endpoint string in the error message as it may contain
+		// credentials - but we do want to indicate whether the failure was in the
+		// default or provided value.
+		epType := "default endpoint"
+		if config.Endpoint != "" {
+			epType = "configured endpoint"
+		}
+		return ETCDConfig{}, errors.Wrap(err, "failed to create driver for "+epType)
 	}
 
 	if backend == nil {


### PR DESCRIPTION
This was broken during review-based refactoring in
* https://github.com/k3s-io/kine/pull/325

We generally don't build with cgo disabled so this wasn't noticed.