### PR TITLE
return url encoding hint with url parse error

### DIFF
--- a/pkg/drivers/nats/config.go
+++ b/pkg/drivers/nats/config.go
@@ -9,6 +9,7 @@ import (
 
 	natsserver "github.com/k3s-io/kine/pkg/drivers/nats/server"
 	"github.com/k3s-io/kine/pkg/tls"
+	"github.com/k3s-io/kine/pkg/util"
 	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
@@ -55,7 +56,7 @@ func parseConnection(dsn string, tlsInfo tls.Config) (*Config, error) {
 	// Parse the first URL in the connection string which contains the
 	// query parameters.
 	connections := strings.Split(dsn, ",")
-	u, err := url.Parse(connections[0])
+	u, err := util.ParseURL(connections[0])
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,7 @@ func parseConnection(dsn string, tlsInfo tls.Config) (*Config, error) {
 			connBuilder.WriteString(",")
 		}
 
-		u, err := url.Parse(c)
+		u, err := util.ParseURL(c)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -208,7 +208,7 @@ func setup(db *sql.DB) error {
 }
 
 func createDBIfNotExist(dataSourceName string) error {
-	u, err := url.Parse(dataSourceName)
+	u, err := util.ParseURL(dataSourceName)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func prepareDSN(dataSourceName string, tlsInfo tls.Config) (string, error) {
 	} else {
 		dataSourceName = "postgres://" + dataSourceName
 	}
-	u, err := url.Parse(dataSourceName)
+	u, err := util.ParseURL(dataSourceName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -8,5 +8,5 @@ import (
 
 func ParseURL(urlStr string) (*url.URL, error) {
 	u, err := url.Parse(urlStr)
-	return u, errors.Wrap(err, "error parsing URL. Ensure that any embedded values such as username & password have been URL encoded")
+	return u, errors.Wrap(err, "failed to parse datastore DSN URL; ensure that parameters containing special characters use percent-encoding")
 }

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -1,15 +1,12 @@
 package util
 
 import (
-	"fmt"
 	"net/url"
+
+	"github.com/pkg/errors"
 )
 
 func ParseURL(urlStr string) (*url.URL, error) {
 	u, err := url.Parse(urlStr)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing URL. Ensure that any embedded values such as username & password have been URL encoded: %w", err)
-	}
-
-	return u, nil
+	return u, errors.Wrap(err, "error parsing URL. Ensure that any embedded values such as username & password have been URL encoded")
 }

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func ParseURL(urlStr string) (*url.URL, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing URL. Ensure that any embedded values such as username & password have been URL encoded: %w", err)
+	}
+
+	return u, nil
+}


### PR DESCRIPTION
Resolves #411 

Wrap parse errors with a hint: `error parsing URL. Ensure that any embedded values such as username & password have been URL encoded: <wrapped error>`