### PR TITLE
Fix markdown to use equals as header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Kine (Kine is not etcd)
-==========================
+Kine (Kine is not etcd)
+=======================
 
 Kine is an etcdshim that translates etcd API to:
 - SQLite


### PR DESCRIPTION
This is standard markdown syntax. Removes the '=====...' in markdown viewers (github etc.)