### PR TITLE
Install golangci-lint version 1 to fix validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk -U add bash coreutils git gcc musl-dev vim less curl wget ca-certificate
 RUN go install golang.org/x/tools/cmd/goimports@cd70d50baa6daa949efa12e295e10829f3a7bd46
 RUN rm -rf /go/src /go/pkg
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s;  \
+    curl -sL https://raw.githubusercontent.com/golangci/golangci-lint/refs/tags/v1.64.8/install.sh | sh -s -- v1.64.8;  \
     fi
 
 ENV SRC_DIR=/go/src/github.com/k3s-io/kine


### PR DESCRIPTION
Latest version of golangci-lint is not compatible with previous version of configuration. In long term would be nice to migrate the configuration, but for quick fix the build can install previous version.