### PR TITLE
Fix CI and add riscv64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Compute checksum for each binary
         run: |
-          arch=("amd64" "arm64" "arm")
+          arch=("amd64" "arm64" "arm" "riscv64" "ppc64le")
           cd dist/artifacts
           for a in "${arch[@]}"; do
             sha256sum kine-"${a}" > sha256sum-"${a}".txt
@@ -76,7 +76,7 @@ jobs:
         if: github.repository_owner == 'k3s-io'
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,linux/ppc64le
           context: .
           target: multi-arch-package
           push: true
@@ -90,7 +90,7 @@ jobs:
         if: github.repository_owner != 'k3s-io'
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,linux/ppc64le
           context: .
           target: multi-arch-package
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Compute checksum for each binary
         run: |
-          arch=("amd64" "arm64" "arm" "riscv64" "ppc64le")
+          arch=("amd64" "arm64" "arm" "riscv64")
           cd dist/artifacts
           for a in "${arch[@]}"; do
             sha256sum kine-"${a}" > sha256sum-"${a}".txt
@@ -76,7 +76,7 @@ jobs:
         if: github.repository_owner == 'k3s-io'
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
           context: .
           target: multi-arch-package
           push: true
@@ -90,7 +90,7 @@ jobs:
         if: github.repository_owner != 'k3s-io'
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
           context: .
           target: multi-arch-package
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ARG TAG
 ARG DRONE_TAG
 ARG ARCH=amd64
 ENV ARCH=${ARCH}
+ENV CGO_ENABLED=1
 
 COPY ./scripts/build ./scripts/version ./scripts/
 COPY ./go.mod ./go.sum ./main.go ./
@@ -63,6 +64,7 @@ ENV SRC_DIR=/go/src/github.com/k3s-io/kine
 WORKDIR ${SRC_DIR}/
 ARG TARGETOS
 ARG TARGETARCH
+ENV CGO_ENABLED=1
 COPY ./scripts/buildx ./scripts/version ./scripts/
 COPY ./go.mod ./go.sum ./main.go ./
 COPY ./pkg ./pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ EXPOSE 2379/tcp
 USER nobody
 ENTRYPOINT ["/bin/kine"]
 
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.20 AS multi-arch-build
+FROM golang:1.24-alpine3.20 AS multi-arch-build
 RUN apk -U add bash coreutils git gcc musl-dev vim less curl wget ca-certificates
 # go imports version gopls/v0.15.3
 # https://github.com/golang/tools/releases/latest

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 		-f Dockerfile --target=binary --output=. .
 
 .PHONY: multi-arch-build
-PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7
+PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,linux/ppc64le
 multi-arch-build:
 	docker buildx build --platform=$(PLATFORMS) --target=multi-arch-binary --output=type=local,dest=bin .
 	mv bin/linux*/kine* bin/

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 		-f Dockerfile --target=binary --output=. .
 
 .PHONY: multi-arch-build
-PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64,linux/ppc64le
+PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
 multi-arch-build:
 	docker buildx build --platform=$(PLATFORMS) --target=multi-arch-binary --output=type=local,dest=bin .
 	mv bin/linux*/kine* bin/

--- a/scripts/build
+++ b/scripts/build
@@ -22,4 +22,4 @@ LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Kine
-CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine
+CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -trimpath -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine

--- a/scripts/build
+++ b/scripts/build
@@ -15,8 +15,8 @@ elif [ ${ARCH} = riscv64 ]; then
     export GOARCH="riscv64"
 fi
 
-if [ "$(uname)" = "Linux" ]; then
-    OTHER_LINKFLAGS="-extldflags -static -s"
+if [ "$(uname)" = "linux" ]; then
+    OTHER_LINKFLAGS="-s -extldflags=-static"
 fi
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"

--- a/scripts/buildx
+++ b/scripts/buildx
@@ -23,11 +23,11 @@ if [ "$TARGETOS" != "linux" ]; then
     OPT_OS="-${TARGETOS}"
 fi
 
-if [ "$TARGETOS" = "Linux" ]; then
-    OTHER_LINKFLAGS="-extldflags -static -s"
+if [ "$TARGETOS" = "linux" ]; then
+    OTHER_LINKFLAGS="-s -extldflags=-static"
 fi
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Mutliplaform Kine
-CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"
+CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -trimpath -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"


### PR DESCRIPTION
Fixes issues with static linking.
Fixes issues with missing CGO/SQLite.
Adds two new architectures to release: `riscv64` ~and `ppc64le`~.

Closes #453 