### PR TITLE
Use tonistiigi/xx to enable CGO multiplatform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -29,7 +26,7 @@ jobs:
 
       - name: Compute checksum for each binary
         run: |
-          arch=("amd64" "arm64" "arm")
+          arch=("amd64" "arm64" "arm" "riscv64")
           cd dist/artifacts
           for a in "${arch[@]}"; do
             sha256sum kine-"${a}" > sha256sum-"${a}".txt

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build:
 		-f Dockerfile --target=binary --output=. .
 
 .PHONY: multi-arch-build
-PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7
+PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
 multi-arch-build:
 	docker buildx build --platform=$(PLATFORMS) --target=multi-arch-binary --output=type=local,dest=bin .
 	mv bin/linux*/kine* bin/

--- a/scripts/buildx
+++ b/scripts/buildx
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Builds kiune from multiple platforms and os
+# Builds kine for multiple platforms and os
 # Intended to be run within a buildx container that provides the --platform flag
+# Also needed are the tonistiigi/xx build tools
 set -e
 
 source $(dirname $0)/version
@@ -8,9 +9,6 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-
-export GOOS=${TARGETOS}
-export GOARCH=${TARGETARCH}
 
 if [ "$TARGETARCH" = "arm/v7" ]; then
     ARCH="-arm"
@@ -23,11 +21,11 @@ if [ "$TARGETOS" != "linux" ]; then
     OPT_OS="-${TARGETOS}"
 fi
 
-if [ "$TARGETOS" = "Linux" ]; then
+if [ "$TARGETOS" = "linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"
 fi
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Mutliplaform Kine
-CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"
+CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" xx-go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"


### PR DESCRIPTION
## Changes
- Fix releases to properly include CGO build of the binaries
- Readds riscv64 builds