### PR TITLE
Remove arm32/64 Drone CI, add PR build checks in GHA

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,9 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
 
 - name: test-image
   image: docker:25.0.5
@@ -142,60 +145,6 @@ steps:
   when:
     event:
     - pull_request
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
-type: docker
-name: arm64
-
-platform:
-  os: linux
-  arch: arm64
-
-steps:
-- name: build
-  image: docker:25.0.5
-  commands:
-  - apk add make git bash file
-  - git config --global --add safe.directory /drone/src
-  - make
-  environment:
-    ARCH: "${DRONE_STAGE_ARCH}"
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
-
----
-kind: pipeline
-type: docker
-name: arm
-
-platform:
-  os: linux
-  arch: arm
-
-steps:
-- name: build
-  image: docker:25.0.5
-  commands:
-  - apk add make git bash file
-  - git config --global --add safe.directory /drone/src
-  - make
-  environment:
-    ARCH: "${DRONE_STAGE_ARCH}"
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
 
 volumes:
 - name: docker

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,23 @@
+name: Pull Request
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: amd64
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build binaries
+        run: make multi-arch-build


### PR DESCRIPTION
- Add CI that checks builds on PR. This covers all 4 platforms we build (armv7, arm64, amd64, riscv64). Ensures dependabot PRs also get some validation.
- Remove Drone arm32 and arm64 CI, no longer used/needed.