### PR TITLE
Configurable compaction and observability enhancements

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -111,6 +111,36 @@ func New() *cli.App {
 			Destination: &config.EmulatedETCDVersion,
 			Value:       "3.5.13",
 		},
+		&cli.DurationFlag{
+			Name:        "compact-interval",
+			Usage:       "Interval between automatic compaction. Default is 5m.",
+			Destination: &config.CompactInterval,
+			Value:       5 * time.Minute,
+		},
+		&cli.DurationFlag{
+			Name:        "compact-timeout",
+			Usage:       "Timeout for automatic compaction. Default is 5s.",
+			Destination: &config.CompactTimeout,
+			Value:       5 * time.Second,
+		},
+		&cli.Int64Flag{
+			Name:        "compact-min-retain",
+			Usage:       "Minimum number of revisions to retain when compacting. Default is 1000.",
+			Destination: &config.CompactMinRetain,
+			Value:       1000,
+		},
+		&cli.Int64Flag{
+			Name:        "compact-batch-size",
+			Usage:       "Number of revisions to compact in a single batch. Default is 1000.",
+			Destination: &config.CompactBatchSize,
+			Value:       1000,
+		},
+		&cli.Int64Flag{
+			Name:        "poll-batch-size",
+			Usage:       "Number of revisions to poll in a single batch. Default is 500.",
+			Destination: &config.PollBatchSize,
+			Value:       500,
+		},
 		&cli.BoolFlag{Name: "debug"},
 	}
 	app.Action = run

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -97,9 +97,15 @@ func New() *cli.App {
 		},
 		&cli.DurationFlag{
 			Name:        "slow-sql-threshold",
-			Usage:       "The duration which SQL executed longer than will be logged. Default 1s, set <= 0 to disable slow SQL log.",
+			Usage:       "The duration which SQL executed longer than will be logged at level info. Default 1s, set <= 0 to disable slow SQL log.",
 			Destination: &metrics.SlowSQLThreshold,
 			Value:       time.Second,
+		},
+		&cli.DurationFlag{
+			Name:        "slow-sql-warning-threshold",
+			Usage:       "The duration which SQL executed longer than will be logged at level warn. Default 5s.",
+			Destination: &metrics.SlowSQLWarningThreshold,
+			Value:       5 * time.Second,
 		},
 		&cli.BoolFlag{
 			Name:        "metrics-enable-profiling",

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -130,6 +130,12 @@ func New() *cli.App {
 			Destination: &config.CompactInterval,
 			Value:       5 * time.Minute,
 		},
+		&cli.IntFlag{
+			Name:        "compact-interval-jitter",
+			Usage:       "Percentage of jitter to apply to interval durations. A value of 10 will apply a jitter of +/-10 percent to the interval duration. It cannot be negative, and must be less than 100. Default is 0.",
+			Destination: &config.CompactIntervalJitter,
+			Value:       0,
+		},
 		&cli.DurationFlag{
 			Name:        "compact-timeout",
 			Usage:       "Timeout for automatic compaction. Default is 5s.",

--- a/pkg/drivers/config.go
+++ b/pkg/drivers/config.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Config struct {
-	MetricsRegisterer    prometheus.Registerer
-	Endpoint             string
-	Scheme               string
-	DataSourceName       string
-	ConnectionPoolConfig generic.ConnectionPoolConfig
-	BackendTLSConfig     tls.Config
-	CompactInterval      time.Duration
-	CompactTimeout       time.Duration
-	CompactMinRetain     int64
-	CompactBatchSize     int64
-	PollBatchSize        int64
+	MetricsRegisterer     prometheus.Registerer
+	Endpoint              string
+	Scheme                string
+	DataSourceName        string
+	ConnectionPoolConfig  generic.ConnectionPoolConfig
+	BackendTLSConfig      tls.Config
+	CompactInterval       time.Duration
+	CompactIntervalJitter int
+	CompactTimeout        time.Duration
+	CompactMinRetain      int64
+	CompactBatchSize      int64
+	PollBatchSize         int64
 }

--- a/pkg/drivers/config.go
+++ b/pkg/drivers/config.go
@@ -1,6 +1,8 @@
 package drivers
 
 import (
+	"time"
+
 	"github.com/k3s-io/kine/pkg/drivers/generic"
 	"github.com/k3s-io/kine/pkg/tls"
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,4 +15,9 @@ type Config struct {
 	DataSourceName       string
 	ConnectionPoolConfig generic.ConnectionPoolConfig
 	BackendTLSConfig     tls.Config
+	CompactInterval      time.Duration
+	CompactTimeout       time.Duration
+	CompactMinRetain     int64
+	CompactBatchSize     int64
+	PollBatchSize        int64
 }

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -444,14 +444,14 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 		err = row.Scan(&id)
 
 		if err != nil && d.InsertRetry != nil && d.InsertRetry(err) {
-			logrus.Warnf("unique violation retry for key %v: %v", key, err)
+			logrus.Warnf("retriable insert error: duplicate key %v violates unique constraint: %v", key, err)
 			metrics.InsertRetriesTotal.WithLabelValues().Inc()
 			wait(i)
 			continue
 		}
 
 		if err != nil {
-			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("unique violation error for key %v: %v", key, err)
+			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("insert error: duplicate key %v violates unique constraint: %v", key, err)
 		}
 
 		return id, err

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -445,13 +445,13 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 
 		if err != nil && d.InsertRetry != nil && d.InsertRetry(err) {
 			logrus.Warnf("retriable insert error for key %v: %v", key, err)
-			metrics.InsertErrorsTotal.WithLabelValues(key, "true").Inc()
+			metrics.InsertErrorsTotal.WithLabelValues("true").Inc()
 			wait(i)
 			continue
 		}
 
 		if err != nil {
-			metrics.InsertErrorsTotal.WithLabelValues(key, "false").Inc()
+			metrics.InsertErrorsTotal.WithLabelValues("false").Inc()
 			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("insert error for key %v: %v", key, err)
 		}
 

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -444,7 +444,7 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 		err = row.Scan(&id)
 
 		if err != nil && d.InsertRetry != nil && d.InsertRetry(err) {
-			logrus.Warnf("retriable insert error: duplicate key %v violates unique constraint: %v", key, err)
+			logrus.Warnf("retriable insert error for key %v: %v", key, err)
 			metrics.InsertErrorsTotal.WithLabelValues(key, "true").Inc()
 			wait(i)
 			continue
@@ -452,7 +452,7 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 
 		if err != nil {
 			metrics.InsertErrorsTotal.WithLabelValues(key, "false").Inc()
-			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("insert error: duplicate key %v violates unique constraint: %v", key, err)
+			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("insert error for key %v: %v", key, err)
 		}
 
 		return id, err

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -445,12 +445,13 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 
 		if err != nil && d.InsertRetry != nil && d.InsertRetry(err) {
 			logrus.Warnf("retriable insert error: duplicate key %v violates unique constraint: %v", key, err)
-			metrics.InsertRetriesTotal.WithLabelValues().Inc()
+			metrics.InsertErrorsTotal.WithLabelValues(key, "true").Inc()
 			wait(i)
 			continue
 		}
 
 		if err != nil {
+			metrics.InsertErrorsTotal.WithLabelValues(key, "false").Inc()
 			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("insert error: duplicate key %v violates unique constraint: %v", key, err)
 		}
 

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -120,7 +120,7 @@ func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error)
 	}
 
 	dialect.Migrate(context.Background())
-	return true, logstructured.New(sqllog.New(dialect)), nil
+	return true, logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -120,7 +120,7 @@ func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error)
 	}
 
 	dialect.Migrate(context.Background())
-	return true, logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), nil
+	return true, logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactIntervalJitter, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -159,7 +159,7 @@ func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error)
 	}
 
 	dialect.Migrate(context.Background())
-	return true, logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), nil
+	return true, logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactIntervalJitter, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -159,7 +159,7 @@ func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error)
 	}
 
 	dialect.Migrate(context.Background())
-	return true, logstructured.New(sqllog.New(dialect)), nil
+	return true, logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -103,7 +103,7 @@ func NewVariant(ctx context.Context, driverName string, cfg *drivers.Config) (se
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect)), dialect, nil
+	return logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), dialect, nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -103,7 +103,7 @@ func NewVariant(ctx context.Context, driverName string, cfg *drivers.Config) (se
 	}
 
 	dialect.Migrate(context.Background())
-	return logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), dialect, nil
+	return logstructured.New(sqllog.New(dialect, cfg.CompactInterval, cfg.CompactIntervalJitter, cfg.CompactTimeout, cfg.CompactMinRetain, cfg.CompactBatchSize, cfg.PollBatchSize)), dialect, nil
 }
 
 func setup(db *sql.DB) error {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -87,7 +87,7 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 			metrics.SQLTotal,
 			metrics.SQLTime,
 			metrics.CompactTotal,
-			metrics.InsertRetriesTotal,
+			metrics.InsertErrorsTotal,
 		)
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -27,21 +27,22 @@ const (
 )
 
 type Config struct {
-	GRPCServer           *grpc.Server
-	Listener             string
-	Endpoint             string
-	ConnectionPoolConfig generic.ConnectionPoolConfig
-	ServerTLSConfig      tls.Config
-	BackendTLSConfig     tls.Config
-	MetricsRegisterer    prometheus.Registerer
-	NotifyInterval       time.Duration
-	EmulatedETCDVersion  string
-	CompactInterval      time.Duration
-	CompactTimeout       time.Duration
-	CompactMinRetain     int64
-	CompactBatchSize     int64
-	PollBatchSize        int64
-	LogFormat            string
+	GRPCServer            *grpc.Server
+	Listener              string
+	Endpoint              string
+	ConnectionPoolConfig  generic.ConnectionPoolConfig
+	ServerTLSConfig       tls.Config
+	BackendTLSConfig      tls.Config
+	MetricsRegisterer     prometheus.Registerer
+	NotifyInterval        time.Duration
+	EmulatedETCDVersion   string
+	CompactInterval       time.Duration
+	CompactIntervalJitter int
+	CompactTimeout        time.Duration
+	CompactMinRetain      int64
+	CompactBatchSize      int64
+	PollBatchSize         int64
+	LogFormat             string
 }
 
 type ETCDConfig struct {
@@ -52,15 +53,16 @@ type ETCDConfig struct {
 
 func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 	leaderElect, backend, err := drivers.New(ctx, &drivers.Config{
-		MetricsRegisterer:    config.MetricsRegisterer,
-		Endpoint:             config.Endpoint,
-		BackendTLSConfig:     config.BackendTLSConfig,
-		ConnectionPoolConfig: config.ConnectionPoolConfig,
-		CompactInterval:      config.CompactInterval,
-		CompactTimeout:       config.CompactTimeout,
-		CompactMinRetain:     config.CompactMinRetain,
-		CompactBatchSize:     config.CompactBatchSize,
-		PollBatchSize:        config.PollBatchSize,
+		MetricsRegisterer:     config.MetricsRegisterer,
+		Endpoint:              config.Endpoint,
+		BackendTLSConfig:      config.BackendTLSConfig,
+		ConnectionPoolConfig:  config.ConnectionPoolConfig,
+		CompactInterval:       config.CompactInterval,
+		CompactIntervalJitter: config.CompactIntervalJitter,
+		CompactTimeout:        config.CompactTimeout,
+		CompactMinRetain:      config.CompactMinRetain,
+		CompactBatchSize:      config.CompactBatchSize,
+		PollBatchSize:         config.PollBatchSize,
 	})
 
 	if err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -36,6 +36,11 @@ type Config struct {
 	MetricsRegisterer    prometheus.Registerer
 	NotifyInterval       time.Duration
 	EmulatedETCDVersion  string
+	CompactInterval      time.Duration
+	CompactTimeout       time.Duration
+	CompactMinRetain     int64
+	CompactBatchSize     int64
+	PollBatchSize        int64
 }
 
 type ETCDConfig struct {
@@ -50,6 +55,11 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 		Endpoint:             config.Endpoint,
 		BackendTLSConfig:     config.BackendTLSConfig,
 		ConnectionPoolConfig: config.ConnectionPoolConfig,
+		CompactInterval:      config.CompactInterval,
+		CompactTimeout:       config.CompactTimeout,
+		CompactMinRetain:     config.CompactMinRetain,
+		CompactBatchSize:     config.CompactBatchSize,
+		PollBatchSize:        config.PollBatchSize,
 	})
 
 	if err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -41,6 +41,7 @@ type Config struct {
 	CompactMinRetain     int64
 	CompactBatchSize     int64
 	PollBatchSize        int64
+	LogFormat            string
 }
 
 type ETCDConfig struct {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -87,6 +87,7 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 			metrics.SQLTotal,
 			metrics.SQLTime,
 			metrics.CompactTotal,
+			metrics.InsertRetriesTotal,
 		)
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,10 +31,10 @@ var (
 		Help: "Total number of compactions",
 	}, []string{"result"})
 
-	InsertRetriesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "kine_insert_retries_total",
+	InsertErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kine_insert_errors_total",
 		Help: "Total number of insert retries due to unique constraint violations",
-	}, []string{})
+	}, []string{"key", "retriable"})
 )
 
 var (
@@ -49,7 +49,7 @@ func ObserveSQL(start time.Time, errCode string, sql util.Stripped, args ...inte
 	duration := time.Since(start)
 	SQLTime.WithLabelValues(errCode).Observe(duration.Seconds())
 	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold {
-		instrumentedLogger := logrus.WithField("sql", sql).WithField("duration", duration)
+		instrumentedLogger := logrus.WithField("duration", duration)
 
 		if logrus.GetLevel() == logrus.TraceLevel {
 			instrumentedLogger.WithField("args", args)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 	InsertErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "kine_insert_errors_total",
 		Help: "Total number of insert retries due to unique constraint violations",
-	}, []string{"key", "retriable"})
+	}, []string{"retriable"})
 )
 
 var (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -48,7 +48,7 @@ func ObserveSQL(start time.Time, errCode string, sql util.Stripped, args ...inte
 	SQLTotal.WithLabelValues(errCode).Inc()
 	duration := time.Since(start)
 	SQLTime.WithLabelValues(errCode).Observe(duration.Seconds())
-	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold && duration < SlowSQLWarningThreshold {
+	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold {
 		instrumentedLogger := logrus.WithField("sql", sql).WithField("duration", duration)
 
 		if logrus.GetLevel() == logrus.TraceLevel {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,6 +30,11 @@ var (
 		Name: "kine_compact_total",
 		Help: "Total number of compactions",
 	}, []string{"result"})
+
+	InsertRetriesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "kine_insert_retries_total",
+		Help: "Total number of insert retries due to unique constraint violations",
+	}, []string{})
 )
 
 var (

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -35,18 +35,25 @@ var (
 var (
 	// SlowSQLThreshold is a duration which SQL executed longer than will be logged.
 	// This can be directly modified to override the default value when kine is used as a library.
-	SlowSQLThreshold = time.Second
+	SlowSQLThreshold        = time.Second
+	SlowSQLWarningThreshold = 5 * time.Second
 )
 
 func ObserveSQL(start time.Time, errCode string, sql util.Stripped, args ...interface{}) {
 	SQLTotal.WithLabelValues(errCode).Inc()
 	duration := time.Since(start)
 	SQLTime.WithLabelValues(errCode).Observe(duration.Seconds())
-	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold {
+	if SlowSQLThreshold > 0 && duration >= SlowSQLThreshold && duration < SlowSQLWarningThreshold {
+		instrumentedLogger := logrus.WithField("sql", sql).WithField("duration", duration)
+
 		if logrus.GetLevel() == logrus.TraceLevel {
-			logrus.Tracef("Slow SQL (started: %v) (total time: %v): %s : %v", start, duration, sql, args)
+			instrumentedLogger.WithField("args", args)
+		}
+
+		if duration < SlowSQLWarningThreshold {
+			instrumentedLogger.Infof("Slow SQL (started: %v) (total time: %v): %s", start, duration, sql)
 		} else {
-			logrus.Infof("Slow SQL (started: %v) (total time: %v): %s", start, duration, sql)
+			instrumentedLogger.Warnf("Slow SQL (started: %v) (total time: %v): %s", start, duration, sql)
 		}
 	}
 }


### PR DESCRIPTION
Hi! I'm pushing upstream some of our changes. All of the changes have been tested in our clusters and are backwards compatible.

1. The compact operation configuration is now exposed via CLI flags: `--compact-timeout`, `--compact-min-retain`, `--compact-batch-size`, and `--poll-batch-size`. We run quite a few clusters and wanted an easier way to tune these settings to optimize our database load. Default values and behavior haven't changed.

2. Added the flag `--metrics-ignore-tls-config`, which, if set to `true`, will expose the `/metrics` endpoint over HTTP without TLS, regardless of the main endpoint's configuration. Not sure if the naming of the flag is perfect, but it simply prevents copying the TLS config in this line: `metricsConfig.ServerTLSConfig = config.ServerTLSConfig`.

3. Added the `--log-format` flag with possible values: `plain` (default) and `json`. Plain logging is the current formatting configuration in Kine.

4. Added logging for "duplicate key value violates unique constraint" errors. Retriable errors are logged as warnings, and non-retriable ones are logged as errors.

5. Added the metric `kine_insert_errors_total` with labels `key` and `retriable` (`"true"`/`"false"`).

6. Adjusted the behavior of slow SQL reporting: queries longer than 5 seconds are now logged as warnings instead of info.

6. Added a new flag `--compact-interval-jitter` to apply a jitter to the interval in order to distribute the load more evenly when multiple Kine instances are set up with the same interval.

I understand it's easier to review smaller PRs, so let me know if you'd prefer this split into smaller pull requests.