### PR TITLE
Reduce k8s dependabot checks to monthly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,11 +41,25 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      k8s-dependencies:
-        patterns:
-          - k8s.io/*
       etcd-dependencies:
         patterns:
           - go.etcd.io/*
     ignore:
+      - dependency-name: k8s.io/*
       - dependency-name: "github.com/nats-io/nats-server/v2"
+
+   # Maintain dependencies for K8s monthly
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "kind/dependabot"
+    reviewers:
+      - "k3s-io/k3s-dev"
+    schedule:
+      interval: "monthly"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - k8s.io/*
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
We don't update k8s dependencies to a new minor comes out every 3 months. Checking every week just cause PR spam.