### PR TITLE
Fix dependabot config for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
   - package-ecosystem: "gomod"
     open-pull-requests-limit: 15
     directory: "/"
+    target-branch: "master" # see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     labels:
       - "kind/dependabot"
     reviewers:


### PR DESCRIPTION
https://github.com/k3s-io/kine/pull/465 Introduced a invalid dependabot config. Unfortunately, this can't be caught in PR due to [how dependabot permissions work.](https://github.com/dependabot/dependabot-core/issues/4605). 

This fixes the configuration and allows for two different `gomod` schedules.