### PR TITLE
Skip logging of ErrKeyExists during insert

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -450,7 +450,7 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 			continue
 		}
 
-		if err != nil {
+		if err != nil && (d.TranslateErr == nil || d.TranslateErr(err) != server.ErrKeyExists) {
 			metrics.InsertErrorsTotal.WithLabelValues("false").Inc()
 			logrus.WithField("key", key).WithField("createRevision", createRevision).WithField("previousRevision", previousRevision).Errorf("insert error for key %v: %v", key, err)
 		}


### PR DESCRIPTION
This change eliminates logging of `duplicate key value violates unique constraint "kine_name_prev_revision_uindex" (SQLSTATE 23505)` (in case of postgresql). There are two reasons to do this:

- ErrKeyExists is a special error, it is not logged when happens on mysql for example.
- ErrKeyExists suspects client error, and handled by client, so it makes sense to skip at Kine side.