### PR TITLE
Fix issue where first arg/flag was ignored when generating config

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -212,7 +211,7 @@ func run(c *cli.Context) error {
 // Config returns the endpoint config provided by parsing the provided CLI flags.
 func Config(args []string) endpoint.Config {
 	a := New()
-	a.Before = func(*cli.Context) error { return errors.New("parse") }
-	a.Run(args)
+	a.Action = func(*cli.Context) error { return nil }
+	a.Run(append([]string{"kine"}, args...))
 	return config
 }


### PR DESCRIPTION
app.Run needs argv[0] set to a command name, not the first flag.