### PR TITLE
Fix build args for multi-arch-build make target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ARCH: amd64
+      TAG: ${{ github.ref_name }}
     permissions:
       contents: write # Needed to update release with binary assets
       packages: write # Needed for GHCR image push

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
 
 FROM infra AS build
 ARG TAG
-ARG DRONE_TAG
+ARG DIRTY
 ARG ARCH=amd64
-ENV ARCH=${ARCH}
+ENV TAG=${TAG} DIRTY=${DIRTY} ARCH=${ARCH}
 
 COPY ./scripts/build ./scripts/version ./scripts/
 COPY ./go.mod ./go.sum ./main.go ./
@@ -57,9 +57,11 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.22 AS multi-arch-build
 COPY --from=xx / /
+ARG TAG
+ARG DIRTY
 ARG TARGETOS
 ARG TARGETARCH
-ENV CGO_ENABLED=1
+ENV TAG=${TAG} DIRTY=${DIRTY} CGO_ENABLED=1
 RUN apk -U add bash coreutils git vim less curl wget ca-certificates clang lld
 RUN xx-apk add musl-dev gcc
 # go imports version gopls/v0.15.3

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 .PHONY: multi-arch-build
 PLATFORMS = linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
 multi-arch-build:
-	docker buildx build --platform=$(PLATFORMS) --target=multi-arch-binary --output=type=local,dest=bin .
+	docker buildx build --build-arg="REPO=$(REPO)" --build-arg="TAG=$(TAG)" --build-arg="DIRTY=$(DIRTY)" --platform=$(PLATFORMS) --target=multi-arch-binary --output=type=local,dest=bin .
 	mv bin/linux*/kine* bin/
 	rmdir bin/linux*
 	mkdir -p dist/artifacts

--- a/scripts/buildx
+++ b/scripts/buildx
@@ -2,7 +2,7 @@
 # Builds kine for multiple platforms and os
 # Intended to be run within a buildx container that provides the --platform flag
 # Also needed are the tonistiigi/xx build tools
-set -e
+set -ex
 
 source $(dirname $0)/version
 
@@ -27,5 +27,5 @@ fi
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
-echo Building Mutliplaform Kine
+echo Building Multiplatform Kine ${VERSION}
 CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" xx-go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -323,12 +323,7 @@ pid-cleanup() {
         printf '\033[32mAll tests passed.\033[m\n'
     else
         printf "\033[31m$failCount tests failed.\033[m\n"
-        if [ "$DRONE_BUILD_EVENT" = 'tag' ]; then
-            printf "\033[31mIgnoring test failures on tag.\033[m\n"
-            code=0
-        else
-            code=1
-        fi
+        code=1
     fi
     echo
     exit $code

--- a/scripts/version
+++ b/scripts/version
@@ -1,14 +1,9 @@
 #!/bin/bash
 
-# Without Dapper, DIRTY is determined in the Makefile and passed in as a build arg/env var
-if [ -z "$DIRTY" ] && [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-    DIRTY="-dirty"
-fi
-
 COMMIT=$(git rev-parse --short HEAD)
-GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
+GIT_TAG=${TAG:-$(git tag -l --contains HEAD | head -n 1)}
 
-if [ -z "$DIRTY" ] && [ -n "$GIT_TAG" ]; then
+if [ -z "$DIRTY" ] && [ -n "$GIT_TAG" ] && [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     VERSION=$GIT_TAG
 else
     VERSION="${COMMIT}${DIRTY}"


### PR DESCRIPTION
Linked issue:
* https://github.com/k3s-io/kine/issues/495

`git status` cannot be used because the Dockerfile doesn't copy in all the files from the working directory; as a result git thinks the files have been deleted and the repo is dirty.