### PR TITLE
Update test to use newer ghcr k3s image

### DIFF
--- a/scripts/test-conformance
+++ b/scripts/test-conformance
@@ -18,12 +18,15 @@ test-conformance() {
     echo "Running conformance tests against $(grep server: $KUBECONFIG)"
     # We can't just mount $KUBECONFIG as a volume, because in CI this script is
     # also running in a docker container, and the mount will not work.
+    # TODO: Once we move to k3s v1.34+, we can stop skipping
+    # DynamicResourceAllocation, WatchList, and OrderedNamespaceDeletion tests
+    # TODO: Once we move to k3s v1.32+, we can remove the E2E_SKIP for WatchListClient
     docker container run \
         --rm -d --name $name \
         --entrypoint /usr/bin/sh \
         -e "KUBECONFIG=/root/.kube/config" \
         -e "E2E_FOCUS=sig-api-machinery" \
-        -e "E2E_SKIP=StorageVersionAPI|Slow|Flaky" \
+        -e "E2E_SKIP=StorageVersionAPI|Slow|Flaky|DynamicResourceAllocation|OrderedNamespaceDeletion|WatchList|WatchListClient" \
         -e "E2E_EXTRA_ARGS=--ginkgo.fail-fast" \
         registry.k8s.io/conformance:$version \
         -c 'mkdir -p /root/.kube; sleep 36000'

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -218,7 +218,7 @@ provision-server() {
         -p $testPort:6443 \
         -e K3S_DEBUG=true \
         -e K3S_DATASTORE_ENDPOINT=$K3S_DATASTORE_ENDPOINT \
-        ${K3S_IMAGE:-docker.io/rancher/k3s:v1.29.4-k3s1} server \
+        ${K3S_IMAGE:-ghcr.io/k3s-io/k3s:v1.31.12-k3s1} server \
         --kube-apiserver-arg=feature-gates=WatchList=true \
         --disable=coredns,servicelb,traefik,local-storage,metrics-server \
         --disable-network-policy

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -212,6 +212,9 @@ provision-server() {
 
     run-function server-pre-hook $count
 
+    # TODO: Once we move to testing with k3s v1.34+, 
+    # we can stop skipping DynamicResourceAllocation and OrderedNamespaceDeletion 
+    # tests in test-confomance script
     docker container run \
         -d --name $name \
         --privileged \


### PR DESCRIPTION
Use a newer v1.30 line and the new GHCR published image.