### PR TITLE
Do not register core metrics in init

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -198,8 +198,9 @@ func run(c *cli.Context) error {
 	if !metricsIgnoreTLSConfig {
 		metricsConfig.ServerTLSConfig = config.ServerTLSConfig
 	}
-	go metrics.Serve(ctx, metricsConfig)
 	config.MetricsRegisterer = metrics.Registry
+	metrics.RegisterCoreCollectors()
+	go metrics.Serve(ctx, metricsConfig)
 	_, err := endpoint.Listen(ctx, config)
 	if err != nil {
 		return err

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -12,7 +12,7 @@ type RegistererGatherer interface {
 
 var Registry RegistererGatherer = prometheus.NewRegistry()
 
-func init() {
+func RegisterCoreCollectors() {
 	Registry.MustRegister(
 		// expose process metrics like CPU, Memory, file descriptor usage etc.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),


### PR DESCRIPTION
Fixes panic when both etcd and kine are in use.

Ref: https://github.com/k3s-io/k3s/actions/runs/17423032792/job/49465181404?pr=12853

```
panic: duplicate metrics collector registration attempted

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc000884140, {0xc0011c9190?, 0x4?, 0xc0010fd2b0?})
	/go/pkg/mod/github.com/prometheus/client_golang@v1.22.0/prometheus/registry.go:406 +0x65
github.com/k3s-io/kine/pkg/drivers/generic.Open({0x7ffed40, 0xc00063cdc0}, {0x6eeef67, 0x7}, {0x7103501, 0x4d}, {0x0?, 0x0?, 0xc001208340?}, {0x7f4b4a0, ...}, ...)
	/go/pkg/mod/github.com/k3s-io/kine@v0.13.17/pkg/drivers/generic/generic.go:197 +0x318
github.com/k3s-io/kine/pkg/drivers/sqlite.NewVariant({0x7ffed40?, 0xc00063cdc0?}, {0x6eeef67?, 0x7?}, 0xc00124d140)
	/go/pkg/mod/github.com/k3s-io/kine@v0.13.17/pkg/drivers/sqlite/sqlite.go:60 +0x105
github.com/k3s-io/kine/pkg/drivers/sqlite.New({0x7ffed40?, 0xc00063cdc0?}, 0x6eeab00?)
	/go/pkg/mod/github.com/k3s-io/kine@v0.13.17/pkg/drivers/sqlite/sqlite.go:47 +0x2c
github.com/k3s-io/kine/pkg/drivers.New({0x7ffed40, 0xc00063cdc0}, 0xc00124d140)
	/go/pkg/mod/github.com/k3s-io/kine@v0.13.17/pkg/drivers/factory.go:20 +0x68
github.com/k3s-io/kine/pkg/endpoint.Listen({_, _}, {0x0, {0x6fadea4, 0x10}, {0x0, 0x0}, {0x0, 0x0, 0x0}, ...})
	/go/pkg/mod/github.com/k3s-io/kine@v0.13.17/pkg/endpoint/endpoint.go:55 +0x1c5
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).startStorage(0xc0006e3140, {0x7ffed40?, 0xc00063cdc0?}, 0x0)
	/go/src/github.com/k3s-io/k3s/pkg/cluster/cluster.go:172 +0x1ca
github.com/k3s-io/k3s/pkg/cluster.(*Cluster).Start(0xc0006e3140, {0x7ffed40, 0xc00063cdc0})
	/go/src/github.com/k3s-io/k3s/pkg/cluster/cluster.go:59 +0x10a
github.com/k3s-io/k3s/pkg/daemons/control.Server({0x7ffed40, 0xc00063cdc0}, 0xc000da4010)
	/go/src/github.com/k3s-io/k3s/pkg/daemons/control/server.go:74 +0x3e
github.com/k3s-io/k3s/pkg/server.StartServer({0x7ffed40, 0xc00063cdc0}, 0xc000da4008, 0x0?)
	/go/src/github.com/k3s-io/k3s/pkg/server/server.go:72 +0x45
github.com/k3s-io/k3s/pkg/cli/server.run(0xc00096ba80, 0xc1ccdc0, {0xc000c578e8, 0x0, 0x41cdc5?}, {0xc000c578e8, 0x0, 0xc000b92701?})
	/go/src/github.com/k3s-io/k3s/pkg/cli/server/server.go:615 +0x3e8a
github.com/k3s-io/k3s/pkg/cli/server.Run(0xc00096ba80?)
	/go/src/github.com/k3s-io/k3s/pkg/cli/server/server.go:48 +0x2f
github.com/urfave/cli/v2.(*Command).Run(0xc0007586e0, 0xc00096ba80, {0xc000814500, 0x2, 0x2})
	/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/command.go:276 +0x7be
github.com/urfave/cli/v2.(*Command).Run(0xc000832160, 0xc00096b880, {0xc000211830, 0x3, 0x3})
	/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/command.go:269 +0xa45
github.com/urfave/cli/v2.(*App).RunContext(0xc0004ab000, {0x7ffecd0, 0xc1f0c20}, {0xc000211830, 0x3, 0x3})
	/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/app.go:333 +0x5a5
github.com/urfave/cli/v2.(*App).Run(...)
	/go/pkg/mod/github.com/urfave/cli/v2@v2.27.7/app.go:307
main.main()
	/go/src/github.com/k3s-io/k3s/cmd/server/main.go:86 +0xd45
```