### PR TITLE
Update kine for compatibility with kubernetes v1.34

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -29,8 +29,10 @@ const (
 var _ server.Dialect = (*Generic)(nil)
 
 var (
-	columns = "kv.id AS theid, kv.name AS thename, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease, kv.value, kv.old_value"
-	revSQL  = `
+	columns    = "kv.id AS theid, kv.name AS thename, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease"
+	withVal    = columns + ", kv.value"
+	withOldVal = withVal + ", kv.old_value"
+	revSQL     = `
 		SELECT MAX(rkv.id) AS id
 		FROM kine AS rkv`
 
@@ -38,8 +40,7 @@ var (
 		SELECT MAX(crkv.prev_revision) AS prev_revision
 		FROM kine AS crkv
 		WHERE crkv.name = 'compact_rev_key'`
-
-	listSQL = fmt.Sprintf(`
+	listFmt = `
 		SELECT *
 		FROM (
 			SELECT (%s), (%s), %s
@@ -57,7 +58,10 @@ var (
 				?
 		) AS lkv
 		ORDER BY lkv.thename ASC
-		`, revSQL, compactRevSQL, columns)
+		`
+	listSQL       = fmt.Sprintf(listFmt, revSQL, compactRevSQL, columns)
+	listValSQL    = fmt.Sprintf(listFmt, revSQL, compactRevSQL, withVal)
+	listOldValSQL = fmt.Sprintf(listFmt, revSQL, compactRevSQL, withOldVal)
 )
 
 type ErrRetry func(error) bool
@@ -73,30 +77,31 @@ type ConnectionPoolConfig struct {
 type Generic struct {
 	sync.Mutex
 
-	LockWrites            bool
-	LastInsertID          bool
-	DB                    *sql.DB
-	GetCurrentSQL         string
-	GetRevisionSQL        string
-	RevisionSQL           string
-	ListRevisionStartSQL  string
-	GetRevisionAfterSQL   string
-	CountCurrentSQL       string
-	CountRevisionSQL      string
-	AfterSQL              string
-	DeleteSQL             string
-	CompactSQL            string
-	UpdateCompactSQL      string
-	PostCompactSQL        string
-	InsertSQL             string
-	FillSQL               string
-	InsertLastInsertIDSQL string
-	GetSizeSQL            string
-	Retry                 ErrRetry
-	InsertRetry           ErrRetry
-	TranslateErr          TranslateErr
-	ErrCode               ErrCode
-	FillRetryDuration     time.Duration
+	LockWrites              bool
+	LastInsertID            bool
+	DB                      *sql.DB
+	GetCurrentSQL           string
+	GetCurrentValSQL        string
+	ListRevisionStartSQL    string
+	ListRevisionStartValSQL string
+	GetRevisionAfterSQL     string
+	GetRevisionAfterValSQL  string
+	CountCurrentSQL         string
+	CountRevisionSQL        string
+	AfterOldValSQL          string
+	DeleteSQL               string
+	CompactSQL              string
+	UpdateCompactSQL        string
+	PostCompactSQL          string
+	InsertSQL               string
+	FillSQL                 string
+	InsertLastInsertIDSQL   string
+	GetSizeSQL              string
+	Retry                   ErrRetry
+	InsertRetry             ErrRetry
+	TranslateErr            TranslateErr
+	ErrCode                 ErrCode
+	FillRetryDuration       time.Duration
 }
 
 func q(sql, param string, numbered bool) string {
@@ -200,15 +205,12 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 	return &Generic{
 		DB: db,
 
-		GetRevisionSQL: q(fmt.Sprintf(`
-			SELECT
-			0, 0, %s
-			FROM kine AS kv
-			WHERE kv.id = ?`, columns), paramCharacter, numbered),
-
-		GetCurrentSQL:        q(fmt.Sprintf(listSQL, "AND mkv.name > ?"), paramCharacter, numbered),
-		ListRevisionStartSQL: q(fmt.Sprintf(listSQL, "AND mkv.id <= ?"), paramCharacter, numbered),
-		GetRevisionAfterSQL:  q(fmt.Sprintf(listSQL, "AND mkv.name > ? AND mkv.id <= ?"), paramCharacter, numbered),
+		GetCurrentSQL:           q(fmt.Sprintf(listSQL, "AND mkv.name > ?"), paramCharacter, numbered),
+		GetCurrentValSQL:        q(fmt.Sprintf(listValSQL, "AND mkv.name > ?"), paramCharacter, numbered),
+		ListRevisionStartSQL:    q(fmt.Sprintf(listSQL, "AND mkv.id <= ?"), paramCharacter, numbered),
+		ListRevisionStartValSQL: q(fmt.Sprintf(listValSQL, "AND mkv.id <= ?"), paramCharacter, numbered),
+		GetRevisionAfterSQL:     q(fmt.Sprintf(listSQL, "AND mkv.name > ? AND mkv.id <= ?"), paramCharacter, numbered),
+		GetRevisionAfterValSQL:  q(fmt.Sprintf(listValSQL, "AND mkv.name > ? AND mkv.id <= ?"), paramCharacter, numbered),
 
 		CountCurrentSQL: q(fmt.Sprintf(`
 			SELECT (%s), COUNT(c.theid)
@@ -222,13 +224,13 @@ func Open(ctx context.Context, driverName, dataSourceName string, connPoolConfig
 				%s
 			) c`, revSQL, fmt.Sprintf(listSQL, "AND mkv.name > ? AND mkv.id <= ?")), paramCharacter, numbered),
 
-		AfterSQL: q(fmt.Sprintf(`
+		AfterOldValSQL: q(fmt.Sprintf(`
 			SELECT (%s), (%s), %s
 			FROM kine AS kv
 			WHERE
 				kv.name LIKE ? AND
 				kv.id > ?
-			ORDER BY kv.id ASC`, revSQL, compactRevSQL, columns), paramCharacter, numbered),
+			ORDER BY kv.id ASC`, revSQL, compactRevSQL, withOldVal), paramCharacter, numbered),
 
 		DeleteSQL: q(`
 			DELETE FROM kine AS kv
@@ -323,34 +325,44 @@ func (d *Generic) PostCompact(ctx context.Context) error {
 	return nil
 }
 
-func (d *Generic) GetRevision(ctx context.Context, revision int64) (*sql.Rows, error) {
-	return d.query(ctx, d.GetRevisionSQL, revision)
-}
-
 func (d *Generic) DeleteRevision(ctx context.Context, revision int64) error {
 	logrus.Tracef("DELETEREVISION %v", revision)
 	_, err := d.execute(ctx, d.DeleteSQL, revision)
 	return err
 }
 
-func (d *Generic) ListCurrent(ctx context.Context, prefix, startKey string, limit int64, includeDeleted bool) (*sql.Rows, error) {
-	sql := d.GetCurrentSQL
+func (d *Generic) ListCurrent(ctx context.Context, prefix, startKey string, limit int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
+	var sql string
+	if keysOnly {
+		sql = d.GetCurrentSQL
+	} else {
+		sql = d.GetCurrentValSQL
+	}
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}
 	return d.query(ctx, sql, prefix, startKey, includeDeleted)
 }
 
-func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted bool) (*sql.Rows, error) {
+func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
+	var sql string
 	if startKey == "" {
-		sql := d.ListRevisionStartSQL
+		if keysOnly {
+			sql = d.ListRevisionStartSQL
+		} else {
+			sql = d.ListRevisionStartValSQL
+		}
 		if limit > 0 {
 			sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 		}
 		return d.query(ctx, sql, prefix, revision, includeDeleted)
 	}
 
-	sql := d.GetRevisionAfterSQL
+	if keysOnly {
+		sql = d.GetRevisionAfterSQL
+	} else {
+		sql = d.GetRevisionAfterValSQL
+	}
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}
@@ -390,7 +402,7 @@ func (d *Generic) CurrentRevision(ctx context.Context) (int64, error) {
 }
 
 func (d *Generic) After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error) {
-	sql := d.AfterSQL
+	sql := d.AfterOldValSQL
 	if limit > 0 {
 		sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
 	}

--- a/pkg/drivers/generic/tx.go
+++ b/pkg/drivers/generic/tx.go
@@ -80,10 +80,6 @@ func (t *Tx) Compact(ctx context.Context, revision int64) (int64, error) {
 	return res.RowsAffected()
 }
 
-func (t *Tx) GetRevision(ctx context.Context, revision int64) (*sql.Rows, error) {
-	return t.query(ctx, t.d.GetRevisionSQL, revision)
-}
-
 func (t *Tx) DeleteRevision(ctx context.Context, revision int64) error {
 	logrus.Tracef("TX DELETEREVISION %v", revision)
 	_, err := t.execute(ctx, t.d.DeleteSQL, revision)

--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -146,7 +146,7 @@ func (b *Backend) Count(ctx context.Context, prefix, startKey string, revision i
 }
 
 // Get returns the store's current revision, the associated server.KeyValue or an error.
-func (b *Backend) Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (int64, *server.KeyValue, error) {
+func (b *Backend) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *server.KeyValue, error) {
 	storeRev := b.kv.BucketRevision()
 	// Get the kv entry and return the revision.
 	rev, nv, err := b.get(ctx, key, revision, false)
@@ -338,8 +338,8 @@ func (b *Backend) Update(ctx context.Context, key string, value []byte, revision
 // that are alphanumerically equal to or greater than the startKey.
 // If limit is provided, the maximum set of matches is limited.
 // If revision is provided, this indicates the maximum revision to return.
-func (b *Backend) List(ctx context.Context, prefix, startKey string, limit, maxRevision int64) (int64, []*server.KeyValue, error) {
-	matches, err := b.kv.List(ctx, prefix, startKey, limit, maxRevision)
+func (b *Backend) List(ctx context.Context, prefix, startKey string, limit, maxRevision int64, keysOnly bool) (int64, []*server.KeyValue, error) {
+	matches, err := b.kv.List(ctx, prefix, startKey, limit, maxRevision, keysOnly)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/pkg/drivers/nats/backend_test.go
+++ b/pkg/drivers/nats/backend_test.go
@@ -168,7 +168,7 @@ func TestBackend_Get(t *testing.T) {
 
 	time.Sleep(2 * time.Millisecond)
 
-	srev, ent, err := b.Get(ctx, "/a", "", 0, 0)
+	srev, ent, err := b.Get(ctx, "/a", "", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, 1, srev)
 	expEqual(t, "/a", ent.Key)
@@ -180,15 +180,15 @@ func TestBackend_Get(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Latest is gone.
-	_, ent, err = b.Get(ctx, "/a", "", 0, 0)
+	_, ent, err = b.Get(ctx, "/a", "", 0, 0, false)
 	expEqualErr(t, nil, err)
 
 	// Get at a revision will fail also.
-	_, ent, err = b.Get(ctx, "/a", "", 0, 1)
+	_, ent, err = b.Get(ctx, "/a", "", 0, 1, false)
 	expEqualErr(t, nil, err)
 
 	// Get at later revision, does not exist.
-	_, _, err = b.Get(ctx, "/a", "", 0, 2)
+	_, _, err = b.Get(ctx, "/a", "", 0, 2, false)
 	expEqualErr(t, nil, err)
 
 	// Create it again and update it.
@@ -200,7 +200,7 @@ func TestBackend_Get(t *testing.T) {
 	noErr(t, err)
 
 	// Get at prior version.
-	rev, ent, err = b.Get(ctx, "/a", "", 0, rev)
+	rev, ent, err = b.Get(ctx, "/a", "", 0, rev, false)
 	noErr(t, err)
 	expEqual(t, 3, rev)
 	expEqual(t, "/a", ent.Key)
@@ -304,28 +304,28 @@ func TestBackend_List(t *testing.T) {
 	time.Sleep(time.Millisecond)
 
 	// List the keys.
-	rev, ents, err := b.List(ctx, "/", "", 0, 0)
+	rev, ents, err := b.List(ctx, "/", "", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, 7, rev)
 	expEqual(t, 7, len(ents))
 	expSortedKeys(t, ents)
 
 	// List the keys with prefix.
-	rev, ents, err = b.List(ctx, "/a", "", 0, 0)
+	rev, ents, err = b.List(ctx, "/a", "", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, 7, rev)
 	expEqual(t, 3, len(ents))
 	expSortedKeys(t, ents)
 
 	// List the keys >= start key.
-	rev, ents, err = b.List(ctx, "/", "b", 0, 0)
+	rev, ents, err = b.List(ctx, "/", "b", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, 7, rev)
 	expEqual(t, 4, len(ents))
 	expSortedKeys(t, ents)
 
 	// List the keys up to a revision.
-	rev, ents, err = b.List(ctx, "/", "", 0, 3)
+	rev, ents, err = b.List(ctx, "/", "", 0, 3, false)
 	noErr(t, err)
 	expEqual(t, 7, rev)
 	expEqual(t, 3, len(ents))
@@ -333,7 +333,7 @@ func TestBackend_List(t *testing.T) {
 	expEqualKeys(t, []string{"/a", "/a/b/c", "/b"}, ents)
 
 	// List the keys with a limit.
-	rev, ents, err = b.List(ctx, "/", "", 4, 0)
+	rev, ents, err = b.List(ctx, "/", "", 4, 0, false)
 	noErr(t, err)
 	expEqual(t, 7, rev)
 	expEqual(t, 4, len(ents))
@@ -341,7 +341,7 @@ func TestBackend_List(t *testing.T) {
 	expEqualKeys(t, []string{"/a", "/a/b", "/a/b/c", "/b"}, ents)
 
 	// List the keys with a limit after some start key.
-	rev, ents, err = b.List(ctx, "/", "b", 2, 0)
+	rev, ents, err = b.List(ctx, "/", "b", 2, 0, false)
 	noErr(t, err)
 	expEqual(t, 7, rev)
 	expEqual(t, 2, len(ents))

--- a/pkg/drivers/nats/kv.go
+++ b/pkg/drivers/nats/kv.go
@@ -433,7 +433,7 @@ func (e *KeyValue) Count(ctx context.Context, prefix, startKey string, revision 
 	return count, nil
 }
 
-func (e *KeyValue) List(ctx context.Context, prefix, startKey string, limit, revision int64) ([]jetstream.KeyValueEntry, error) {
+func (e *KeyValue) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) ([]jetstream.KeyValueEntry, error) {
 	seekKey := prefix
 	if startKey != "" {
 		seekKey = strings.TrimSuffix(seekKey, "/")

--- a/pkg/drivers/nats/logger.go
+++ b/pkg/drivers/nats/logger.go
@@ -31,7 +31,7 @@ func (b *BackendLogger) Start(ctx context.Context) error {
 }
 
 // Get returns the store's current revision, the associated server.KeyValue or an error.
-func (b *BackendLogger) Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (revRet int64, kvRet *server.KeyValue, errRet error) {
+func (b *BackendLogger) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (revRet int64, kvRet *server.KeyValue, errRet error) {
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
@@ -43,7 +43,7 @@ func (b *BackendLogger) Get(ctx context.Context, key, rangeEnd string, limit, re
 		b.logMethod(dur, fStr, key, revision, revRet, kvRet != nil, size, errRet, dur)
 	}()
 
-	return b.backend.Get(ctx, key, rangeEnd, limit, revision)
+	return b.backend.Get(ctx, key, rangeEnd, limit, revision, keysOnly)
 }
 
 // Create attempts to create the key-value entry and returns the revision number.
@@ -69,7 +69,7 @@ func (b *BackendLogger) Delete(ctx context.Context, key string, revision int64) 
 	return b.backend.Delete(ctx, key, revision)
 }
 
-func (b *BackendLogger) List(ctx context.Context, prefix, startKey string, limit, revision int64) (revRet int64, kvRet []*server.KeyValue, errRet error) {
+func (b *BackendLogger) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (revRet int64, kvRet []*server.KeyValue, errRet error) {
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
@@ -77,7 +77,7 @@ func (b *BackendLogger) List(ctx context.Context, prefix, startKey string, limit
 		b.logMethod(dur, fStr, prefix, startKey, limit, revision, revRet, len(kvRet), errRet, dur)
 	}()
 
-	return b.backend.List(ctx, prefix, startKey, limit, revision)
+	return b.backend.List(ctx, prefix, startKey, limit, revision, keysOnly)
 }
 
 // Count returns an exact count of the number of matching keys and the current revision of the database

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -20,7 +20,7 @@ type Log interface {
 	Start(ctx context.Context) error
 	CompactRevision(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeletes bool) (int64, []*server.Event, error)
+	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeletes, keysOnly bool) (int64, []*server.Event, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
 	After(ctx context.Context, prefix string, revision, limit int64) (int64, []*server.Event, error)
 	Watch(ctx context.Context, prefix string) <-chan []*server.Event
@@ -59,21 +59,21 @@ func (l *LogStructured) Start(ctx context.Context) error {
 	return nil
 }
 
-func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (revRet int64, kvRet *server.KeyValue, errRet error) {
+func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (revRet int64, kvRet *server.KeyValue, errRet error) {
 	defer func() {
 		l.adjustRevision(ctx, &revRet)
 		logrus.Tracef("GET %s, rev=%d => rev=%d, kv=%v, err=%v", key, revision, revRet, kvRet != nil, errRet)
 	}()
 
-	rev, event, err := l.get(ctx, key, rangeEnd, limit, revision, false)
+	rev, event, err := l.get(ctx, key, rangeEnd, limit, revision, false, keysOnly)
 	if event == nil {
 		return rev, nil, err
 	}
 	return rev, event.KV, err
 }
 
-func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, revision int64, includeDeletes bool) (int64, *server.Event, error) {
-	rev, events, err := l.log.List(ctx, key, rangeEnd, limit, revision, includeDeletes)
+func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, revision int64, includeDeletes, keysOnly bool) (int64, *server.Event, error) {
+	rev, events, err := l.log.List(ctx, key, rangeEnd, limit, revision, includeDeletes, keysOnly)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -102,7 +102,7 @@ func (l *LogStructured) Create(ctx context.Context, key string, value []byte, le
 		logrus.Tracef("CREATE %s, size=%d, lease=%d => rev=%d, err=%v", key, len(value), lease, revRet, errRet)
 	}()
 
-	rev, prevEvent, err := l.get(ctx, key, "", 1, 0, true)
+	rev, prevEvent, err := l.get(ctx, key, "", 1, 0, true, false)
 	if err != nil {
 		return 0, err
 	}
@@ -134,7 +134,7 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 		logrus.Tracef("DELETE %s, rev=%d => rev=%d, kv=%v, deleted=%v, err=%v", key, revision, revRet, kvRet != nil, deletedRet, errRet)
 	}()
 
-	rev, event, err := l.get(ctx, key, "", 1, 0, true)
+	rev, event, err := l.get(ctx, key, "", 1, 0, true, false)
 	if err != nil {
 		return 0, nil, false, err
 	}
@@ -161,7 +161,7 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 	if err != nil {
 		// If error on Append we assume it's a UNIQUE constraint error, so we fetch the latest (if we can)
 		// and return that the delete failed
-		latestRev, latestEvent, latestErr := l.get(ctx, key, "", 1, 0, true)
+		latestRev, latestEvent, latestErr := l.get(ctx, key, "", 1, 0, true, false)
 		if latestErr != nil || latestEvent == nil {
 			return rev, event.KV, false, nil
 		}
@@ -170,12 +170,12 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 	return rev, event.KV, true, err
 }
 
-func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit, revision int64) (revRet int64, kvRet []*server.KeyValue, errRet error) {
+func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (revRet int64, kvRet []*server.KeyValue, errRet error) {
 	defer func() {
 		logrus.Tracef("LIST %s, start=%s, limit=%d, rev=%d => rev=%d, kvs=%d, err=%v", prefix, startKey, limit, revision, revRet, len(kvRet), errRet)
 	}()
 
-	rev, events, err := l.log.List(ctx, prefix, startKey, limit, revision, false)
+	rev, events, err := l.log.List(ctx, prefix, startKey, limit, revision, false, keysOnly)
 	if err != nil {
 		return rev, nil, err
 	}
@@ -188,7 +188,7 @@ func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit
 		if err != nil {
 			return currentRev, nil, err
 		}
-		return l.List(ctx, prefix, startKey, limit, currentRev)
+		return l.List(ctx, prefix, startKey, limit, currentRev, keysOnly)
 	} else if revision != 0 {
 		rev = revision
 	}
@@ -215,7 +215,7 @@ func (l *LogStructured) Count(ctx context.Context, prefix, startKey string, revi
 		if err != nil {
 			return 0, 0, err
 		}
-		rev, rows, err := l.List(ctx, prefix, prefix, 1000, currentRev)
+		rev, rows, err := l.List(ctx, prefix, prefix, 1000, currentRev, true)
 		return rev, int64(len(rows)), err
 	}
 	return rev, count, nil
@@ -231,7 +231,7 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 		logrus.Tracef("UPDATE %s, value=%d, rev=%d, lease=%v => rev=%d, kvrev=%d, updated=%v, err=%v", key, len(value), revision, lease, revRet, kvRev, updateRet, errRet)
 	}()
 
-	rev, event, err := l.get(ctx, key, "", 1, 0, false)
+	rev, event, err := l.get(ctx, key, "", 1, 0, false, false)
 	if err != nil {
 		return 0, nil, false, err
 	}
@@ -256,7 +256,7 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 
 	rev, err = l.log.Append(ctx, updateEvent)
 	if err != nil {
-		rev, event, err := l.get(ctx, key, "", 1, 0, false)
+		rev, event, err := l.get(ctx, key, "", 1, 0, false, false)
 		if event == nil {
 			return rev, nil, false, err
 		}
@@ -349,7 +349,7 @@ func (l *LogStructured) ttlEvents(ctx context.Context) chan *server.Event {
 	go func() {
 		defer close(result)
 
-		rev, events, err := l.log.List(ctx, "/", "", 1000, 0, false)
+		rev, events, err := l.log.List(ctx, "/", "", 1000, 0, false, false)
 		for len(events) > 0 {
 			if err != nil {
 				logrus.Errorf("TTL event list failed: %v", err)
@@ -362,7 +362,7 @@ func (l *LogStructured) ttlEvents(ctx context.Context) chan *server.Event {
 				}
 			}
 
-			_, events, err = l.log.List(ctx, "/", events[len(events)-1].KV.Key, 1000, rev, false)
+			_, events, err = l.log.List(ctx, "/", events[len(events)-1].KV.Key, 1000, rev, false, false)
 		}
 
 		wr := l.Watch(ctx, "/", rev)

--- a/pkg/server/get.go
+++ b/pkg/server/get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -18,7 +19,8 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		key = compactRevAPI
 	}
 
-	rev, kv, err := l.backend.Get(ctx, key, string(r.RangeEnd), r.Limit, r.Revision)
+	rev, kv, err := l.backend.Get(ctx, key, string(r.RangeEnd), r.Limit, r.Revision, r.KeysOnly)
+	logrus.Tracef("GET key=%s, end=%s, revision=%d, currentRev=%d, limit=%d, keysOnly=%v", r.Key, r.RangeEnd, r.Revision, rev, r.Limit, r.KeysOnly)
 	resp := &RangeResponse{
 		Header: txnHeader(rev),
 	}

--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -86,6 +86,10 @@ func toKV(kv *KeyValue) *mvccpb.KeyValue {
 	if kv == nil {
 		return nil
 	}
+	// fix up apiserver watch with original compact revision key
+	if kv.Key == compactRevAPI {
+		kv.Key = compactRevKey
+	}
 	return &mvccpb.KeyValue{
 		Key:            []byte(kv.Key),
 		Value:          kv.Value,

--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -13,10 +13,6 @@ import (
 var _ etcdserverpb.KVServer = (*KVServerBridge)(nil)
 
 func (k *KVServerBridge) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*etcdserverpb.RangeResponse, error) {
-	if r.KeysOnly {
-		return nil, unsupported("keysOnly")
-	}
-
 	if r.MaxCreateRevision != 0 {
 		return nil, unsupported("maxCreateRevision")
 	}

--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -37,8 +37,8 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		limit++
 	}
 
-	rev, kvs, err := l.backend.List(ctx, prefix, start, limit, revision)
-	logrus.Tracef("LIST key=%s, end=%s, revision=%d, currentRev=%d count=%d, limit=%d", r.Key, r.RangeEnd, revision, rev, len(kvs), r.Limit)
+	rev, kvs, err := l.backend.List(ctx, prefix, start, limit, revision, r.KeysOnly)
+	logrus.Tracef("LIST key=%s, end=%s, revision=%d, currentRev=%d count=%d, limit=%d, keysOnly=%v", r.Key, r.RangeEnd, revision, rev, len(kvs), r.Limit, r.KeysOnly)
 	resp := &RangeResponse{
 		Header: txnHeader(rev),
 		Count:  int64(len(kvs)),

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -20,10 +20,10 @@ var (
 
 type Backend interface {
 	Start(ctx context.Context) error
-	Get(ctx context.Context, key, rangeEnd string, limit, revision int64) (int64, *KeyValue, error)
+	Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *KeyValue, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64) (int64, []*KeyValue, error)
+	List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (int64, []*KeyValue, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
 	Watch(ctx context.Context, key string, revision int64) WatchResult
@@ -33,15 +33,14 @@ type Backend interface {
 }
 
 type Dialect interface {
-	ListCurrent(ctx context.Context, prefix, startKey string, limit int64, includeDeleted bool) (*sql.Rows, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted bool) (*sql.Rows, error)
+	ListCurrent(ctx context.Context, prefix, startKey string, limit int64, includeDeleted, keysOnly bool) (*sql.Rows, error)
+	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error)
 	CountCurrent(ctx context.Context, prefix, startKey string) (int64, int64, error)
 	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
 	//nolint:revive
 	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value, prevValue []byte) (int64, error)
-	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
 	DeleteRevision(ctx context.Context, revision int64) error
 	GetCompactRevision(ctx context.Context) (int64, error)
 	SetCompactRevision(ctx context.Context, revision int64) error
@@ -62,7 +61,6 @@ type Transaction interface {
 	GetCompactRevision(ctx context.Context) (int64, error)
 	SetCompactRevision(ctx context.Context, revision int64) error
 	Compact(ctx context.Context, revision int64) (int64, error)
-	GetRevision(ctx context.Context, revision int64) (*sql.Rows, error)
 	DeleteRevision(ctx context.Context, revision int64) error
 	CurrentRevision(ctx context.Context) (int64, error)
 }

--- a/pkg/server/update.go
+++ b/pkg/server/update.go
@@ -33,7 +33,7 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 	if rev == 0 {
 		rev, err = l.backend.Create(ctx, key, value, lease)
 		if err == ErrKeyExists {
-			rev, kv, err = l.backend.Get(ctx, key, "", 1, rev)
+			rev, kv, err = l.backend.Get(ctx, key, "", 1, rev, false)
 		} else {
 			ok = true
 		}

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -88,6 +88,11 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 	key := string(r.Key)
 	startRevision := r.StartRevision
 
+	// redirect apiserver watches to the substitute compact revision key
+	if key == compactRevKey {
+		key = compactRevAPI
+	}
+
 	var progressCh chan int64
 	if r.ProgressNotify {
 		progressCh = make(chan int64)


### PR DESCRIPTION
* Allow apiserver to watch the compact rev key, by redirecting list/get/watch to the substitute key
  The apiserver now watches the compact rev key and prunes caches based on the compact revision.
  Ref: https://github.com/kubernetes/kubernetes/pull/132876
  This is a follow-up to: **Add support for apiserver-managed compact** https://github.com/k3s-io/kine/commit/6c30f90141376d669405611a29220cde98f35717
  In order for the 1.34+ apiserver to work properly, kine should be used with `--compact-interval=0` to let the apiserver manage compaction.
* Add support for `clientv3.WithKeysOnly()` list/get option.
  Ref: https://github.com/kubernetes/kubernetes/pull/132355
  Kubernetes no longer uses `WithCountOnly()` to count keys under a prefix; it now uses `WithKeysOnly()` to list all keys under a prefix and then counts those. On the backend, we now only include the value and prev_value columns as necessary, which should make a number of queries more efficient.