### PR TITLE
Add WaitGroup support for graceful shutdown

### DIFF
--- a/pkg/drivers/http/http.go
+++ b/pkg/drivers/http/http.go
@@ -2,12 +2,13 @@ package http
 
 import (
 	"context"
+	"sync"
 
 	"github.com/k3s-io/kine/pkg/drivers"
 	"github.com/k3s-io/kine/pkg/server"
 )
 
-func New(ctx context.Context, cfg *drivers.Config) (leaderElect bool, backend server.Backend, err error) {
+func New(_ context.Context, _ *sync.WaitGroup, _ *drivers.Config) (leaderElect bool, backend server.Backend, err error) {
 	return true, nil, nil
 }
 

--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
@@ -54,7 +55,7 @@ var (
 	createDB = "CREATE DATABASE IF NOT EXISTS `%s`;"
 )
 
-func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error) {
+func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, server.Backend, error) {
 	tlsConfig, err := cfg.BackendTLSConfig.ClientConfig()
 	if err != nil {
 		return false, nil, err
@@ -73,7 +74,7 @@ func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error)
 		return false, nil, err
 	}
 
-	dialect, err := generic.Open(ctx, "mysql", parsedDSN, cfg.ConnectionPoolConfig, "?", false, cfg.MetricsRegisterer)
+	dialect, err := generic.Open(ctx, wg, "mysql", parsedDSN, cfg.ConnectionPoolConfig, "?", false, cfg.MetricsRegisterer)
 	if err != nil {
 		return false, nil, err
 	}

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgerrcode"
@@ -59,7 +60,7 @@ var (
 	createDB = `CREATE DATABASE "%s";`
 )
 
-func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error) {
+func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, server.Backend, error) {
 	parsedDSN, err := prepareDSN(cfg.DataSourceName, cfg.BackendTLSConfig)
 	if err != nil {
 		return false, nil, err
@@ -69,7 +70,7 @@ func New(ctx context.Context, cfg *drivers.Config) (bool, server.Backend, error)
 		return false, nil, err
 	}
 
-	dialect, err := generic.Open(ctx, "pgx", parsedDSN, cfg.ConnectionPoolConfig, "$", true, cfg.MetricsRegisterer)
+	dialect, err := generic.Open(ctx, wg, "pgx", parsedDSN, cfg.ConnectionPoolConfig, "$", true, cfg.MetricsRegisterer)
 	if err != nil {
 		return false, nil, err
 	}

--- a/pkg/drivers/registry.go
+++ b/pkg/drivers/registry.go
@@ -2,12 +2,13 @@ package drivers
 
 import (
 	"context"
+	"sync"
 
 	"github.com/k3s-io/kine/pkg/server"
 )
 
-// Constructor is a function that takes a context and a config and returns a leaderElect bool, a server.Backend and an error
-type Constructor func(ctx context.Context, cfg *Config) (leaderElect bool, backend server.Backend, err error)
+// Constructor is a function that takes a context, waitgroup, and config and returns a leaderElect bool, a server.Backend and an error
+type Constructor func(ctx context.Context, wg *sync.WaitGroup, cfg *Config) (leaderElect bool, backend server.Backend, err error)
 
 var driverRegistry = map[string]Constructor{}
 var defaultScheme string

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync"
 
 	"github.com/k3s-io/kine/pkg/drivers"
 	"github.com/k3s-io/kine/pkg/drivers/generic"
@@ -15,11 +16,11 @@ import (
 
 var errNoCgo = errors.New("this binary is built without CGO, sqlite is disabled")
 
-func New(_ context.Context, _ *drivers.Config) (bool, server.Backend, error) {
+func New(_ context.Context, _ *sync.WaitGroup, _ *drivers.Config) (bool, server.Backend, error) {
 	return false, nil, errNoCgo
 }
 
-func NewVariant(_ context.Context, _ string, cfg *drivers.Config) (server.Backend, *generic.Generic, error) {
+func NewVariant(_ context.Context, _ *sync.WaitGroup, _ string, cfg *drivers.Config) (server.Backend, *generic.Generic, error) {
 	return nil, nil, errNoCgo
 }
 


### PR DESCRIPTION
Gracefully shuts down the GRPC server and closes databases connections, instead of just terminating.

Shutdown will be immediate if there are no streaming clients; if clients are connected it will wait up to 2 seconds for them to close any active streams before stopping.

```console
brandond@dev01:~/go/src/github.com/k3s-io/kine$ ./bin/kine
INFO[2025-09-13T21:21:40.313257287Z] metrics server is starting to listen at :8080
INFO[2025-09-13T21:21:40.313628548Z] starting metrics server path /metrics
INFO[2025-09-13T21:21:40.313940540Z] Configuring sqlite3 database connection pooling: maxIdleConns=2, maxOpenConns=0, connMaxLifetime=0s
INFO[2025-09-13T21:21:40.314009917Z] Configuring database table schema and indexes, this may take a moment...
INFO[2025-09-13T21:21:40.319117746Z] Database tables and indexes are up to date
INFO[2025-09-13T21:21:40.320152871Z] Kine available at http://127.0.0.1:2379
^C
INFO[2025-09-13T21:22:20.767227385Z] Initiating graceful shutdown of Kine GRPC server...
INFO[2025-09-13T21:22:30.803024002Z] TTL events watch channel closed
INFO[2025-09-13T21:22:30.803079490Z] Closing database connections...
INFO[2025-09-13T21:22:30.803097292Z] TTL events work queue has shut down
brandond@dev01:~/go/src/github.com/k3s-io/kine$
```