### PR TITLE
Fix mysql schema migration creating duplicate indexes

### DIFF
--- a/pkg/drivers/mysql/mysql.go
+++ b/pkg/drivers/mysql/mysql.go
@@ -47,7 +47,7 @@ var (
 		`CREATE UNIQUE INDEX kine_name_prev_revision_uindex ON kine (name, prev_revision)`,
 	}
 	schemaMigrations = []string{
-		`ALTER TABLE kine MODIFY COLUMN id BIGINT UNSIGNED AUTO_INCREMENT NOT NULL UNIQUE, MODIFY COLUMN create_revision BIGINT UNSIGNED, MODIFY COLUMN prev_revision BIGINT UNSIGNED`,
+		`ALTER TABLE kine MODIFY COLUMN id BIGINT UNSIGNED AUTO_INCREMENT, MODIFY COLUMN create_revision BIGINT UNSIGNED, MODIFY COLUMN prev_revision BIGINT UNSIGNED`,
 		// Creating an empty migration to ensure that postgresql and mysql migrations match up
 		// with each other for a give value of KINE_SCHEMA_MIGRATION env var
 		``,


### PR DESCRIPTION
We just need to change the datatype, we don't need to re-specify 'NOT NULL UNIQUE' as doing so will create another index every time it's run.

Issue:
* https://github.com/k3s-io/kine/issues/517

Confirmed correct migration with no duplicate index:
```
MariaDB [k3s]> show create table kine\G
*************************** 1. row ***************************
       Table: kine
Create Table: CREATE TABLE `kine` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `name` varchar(630) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
  `created` int(11) DEFAULT NULL,
  `deleted` int(11) DEFAULT NULL,
  `create_revision` int(11) DEFAULT NULL,
  `prev_revision` int(11) DEFAULT NULL,
  `lease` int(11) DEFAULT NULL,
  `value` mediumblob DEFAULT NULL,
  `old_value` mediumblob DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `kine_name_prev_revision_uindex` (`name`,`prev_revision`),
  KEY `kine_name_index` (`name`),
  KEY `kine_name_id_index` (`name`,`id`),
  KEY `kine_id_deleted_index` (`id`,`deleted`),
  KEY `kine_prev_revision_index` (`prev_revision`)
) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
1 row in set (0.000 sec)

MariaDB [k3s]> show create table kine\G
*************************** 1. row ***************************
       Table: kine
Create Table: CREATE TABLE `kine` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(630) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
  `created` int(11) DEFAULT NULL,
  `deleted` int(11) DEFAULT NULL,
  `create_revision` bigint(20) unsigned DEFAULT NULL,
  `prev_revision` bigint(20) unsigned DEFAULT NULL,
  `lease` int(11) DEFAULT NULL,
  `value` mediumblob DEFAULT NULL,
  `old_value` mediumblob DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `kine_name_prev_revision_uindex` (`name`,`prev_revision`),
  KEY `kine_name_index` (`name`),
  KEY `kine_name_id_index` (`name`,`id`),
  KEY `kine_id_deleted_index` (`id`,`deleted`),
  KEY `kine_prev_revision_index` (`prev_revision`)
) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
1 row in set (0.000 sec)
```