### PR TITLE
Fix sql: expected 10 destination arguments in Scan, not 9 on postgresql

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -87,23 +87,6 @@ steps:
     event:
     - pull_request
 
-- name: test-cockroachdb
-  image: docker:25.0.5
-  depends_on:
-   - build
-   - test-image
-  commands:
-  - > 
-    docker run -i -e ARCH -e REPO -e TAG  -e DRONE_TAG -e IMAGE_NAME
-    -v /var/run/docker.sock:/var/run/docker.sock -v kine-cache:/go/src/github.com/k3s-io/kine/.cache
-    --privileged kine:test-${DRONE_COMMIT} "./scripts/test cockroachdb"
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-  when:
-    event:
-    - pull_request
-
 - name: test-schema-migration
   image: docker:25.0.5
   depends_on:

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -95,6 +95,7 @@ func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, se
 			maxkv.deleted = 0 OR ?
 		ORDER BY maxkv.name, maxkv.theid DESC
 	`
+	listSQL := fmt.Sprintf(listFmt, columns)
 	listValSQL := fmt.Sprintf(listFmt, withVal)
 
 	countSQL := `
@@ -130,9 +131,12 @@ func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, se
 				kd.id <= $2
 		) AS ks
 		WHERE kv.id = ks.id`
-	dialect.GetCurrentSQL = q(fmt.Sprintf(listValSQL, "AND kv.name > ?"))
-	dialect.ListRevisionStartSQL = q(fmt.Sprintf(listValSQL, "AND kv.id <= ?"))
-	dialect.GetRevisionAfterSQL = q(fmt.Sprintf(listValSQL, "AND kv.name > ? AND kv.id <= ?"))
+	dialect.GetCurrentSQL = q(fmt.Sprintf(listSQL, "AND kv.name > ?"))
+	dialect.GetCurrentValSQL = q(fmt.Sprintf(listValSQL, "AND kv.name > ?"))
+	dialect.ListRevisionStartSQL = q(fmt.Sprintf(listSQL, "AND kv.id <= ?"))
+	dialect.ListRevisionStartValSQL = q(fmt.Sprintf(listValSQL, "AND kv.id <= ?"))
+	dialect.GetRevisionAfterSQL = q(fmt.Sprintf(listSQL, "AND kv.name > ? AND kv.id <= ?"))
+	dialect.GetRevisionAfterValSQL = q(fmt.Sprintf(listValSQL, "AND kv.name > ? AND kv.id <= ?"))
 	dialect.CountCurrentSQL = q(fmt.Sprintf(countSQL, "AND kv.name > ?"))
 	dialect.CountRevisionSQL = q(fmt.Sprintf(countSQL, "AND kv.name > ? AND kv.id <= ?"))
 	dialect.FillRetryDuration = time.Millisecond + 5

--- a/scripts/test-conformance
+++ b/scripts/test-conformance
@@ -18,15 +18,12 @@ test-conformance() {
     echo "Running conformance tests against $(grep server: $KUBECONFIG)"
     # We can't just mount $KUBECONFIG as a volume, because in CI this script is
     # also running in a docker container, and the mount will not work.
-    # TODO: Once we move to k3s v1.34+, we can stop skipping
-    # DynamicResourceAllocation, WatchList, and OrderedNamespaceDeletion tests
-    # TODO: Once we move to k3s v1.32+, we can remove the E2E_SKIP for WatchListClient
     docker container run \
         --rm -d --name $name \
         --entrypoint /usr/bin/sh \
         -e "KUBECONFIG=/root/.kube/config" \
         -e "E2E_FOCUS=sig-api-machinery" \
-        -e "E2E_SKIP=StorageVersionAPI|Slow|Flaky|DynamicResourceAllocation|OrderedNamespaceDeletion|WatchList|WatchListClient" \
+        -e "E2E_SKIP=StorageVersionAPI|Slow|Flaky|Feature:OffByDefault" \
         -e "E2E_EXTRA_ARGS=--ginkgo.fail-fast" \
         registry.k8s.io/conformance:$version \
         -c 'mkdir -p /root/.kube; sleep 36000'

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -191,11 +191,24 @@ export -f wait-for-kubeconfig
 
 # ---
 
+wait-for-apiserver() {
+    local num=${1:-1}
+    local name=$(cat $TEST_DIR/servers/$num/metadata/name)
+    while ! docker exec -i $name kubectl --request-timeout=5s version; do
+        echo 'Waiting for apiserver to become available...' &>2
+        sleep 5
+    done
+}
+export -f wait-for-apiserver
+
+# ---
+
 provision-cluster() {
     run-function cluster-pre-hook
 
     provision-server
     timeout --foreground 120s bash -c "wait-for-kubeconfig $i"
+    timeout --foreground 120s bash -c "wait-for-apiserver $i"
     export KUBECONFIG=$TEST_DIR/servers/1/kubeconfig.yaml
 
     run-function cluster-post-hook
@@ -212,16 +225,13 @@ provision-server() {
 
     run-function server-pre-hook $count
 
-    # TODO: Once we move to testing with k3s v1.34+, 
-    # we can stop skipping DynamicResourceAllocation and OrderedNamespaceDeletion 
-    # tests in test-confomance script
     docker container run \
         -d --name $name \
         --privileged \
         -p $testPort:6443 \
         -e K3S_DEBUG=true \
         -e K3S_DATASTORE_ENDPOINT=$K3S_DATASTORE_ENDPOINT \
-        ${K3S_IMAGE:-ghcr.io/k3s-io/k3s:v1.31.12-k3s1} server \
+        ${K3S_IMAGE:-ghcr.io/k3s-io/k3s:v1.34.1-k3s1} server \
         --kube-apiserver-arg=feature-gates=WatchList=true \
         --disable=coredns,servicelb,traefik,local-storage,metrics-server \
         --disable-network-policy
@@ -253,6 +263,7 @@ provision-kine() {
         -d --name $name \
         $KINE_ENV \
         $KINE_IMAGE \
+        --compact-interval=0 \
         --watch-progress-notify-interval=5s \
         --endpoint=$KINE_ENDPOINT
 

--- a/scripts/test-load
+++ b/scripts/test-load
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 cd $(dirname $0)/..
 
 if [[ "$LABEL" = "" ]]; then
@@ -11,6 +12,8 @@ test-load() {
         python3 hack/loadmap.py &
     done
     wait
+    loadret=$?
+    echo "Loadmap wait exited with code $loadret"
     python3 hack/histogram.py --backend-name "$LABEL" | awk '{print "[PERF]\t" $0}'
 }
 


### PR DESCRIPTION
Using postgresql driver some requests fails with `sql: expected 10 destination arguments in Scan, not 9` at https://github.com/k3s-io/kine/blob/adbb708512a6be82e7f1beaabc618b95f490d820/pkg/logstructured/sqllog/sql.go#L658. As i think the driver doesn't take care on `keysOnly` properly and uses wrong query which contains the values too.

Here is the query used for `keysOnly = true`:
```sql
SELECT
    (SELECT MAX(rkv.id) AS id FROM kine AS rkv),
    (SELECT MAX(crkv.prev_revision) AS prev_revision FROM kine AS crkv WHERE crkv.name = 'compact_rev_key'),
    maxkv.*
FROM (
    SELECT DISTINCT ON (name)
        kv.id AS theid, kv.name, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease, kv.value
    FROM
        kine AS kv
    WHERE
        kv.name LIKE $1 
        AND kv.name > $2
    ORDER BY kv.name, theid DESC
) AS maxkv
WHERE
    (maxkv.deleted = 0 OR $3) 
ORDER BY maxkv.name, maxkv.theid DESC
LIMIT 1001
```