### PR TITLE
Fixing data race in sql.go

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/k3s-io/kine/pkg/broadcaster"
@@ -22,7 +23,7 @@ type SQLLog struct {
 	broadcaster           broadcaster.Broadcaster
 	ctx                   context.Context
 	notify                chan int64
-	currentRev            int64
+	currentRev            atomic.Int64
 	compactInterval       time.Duration
 	compactIntervalJitter int
 	compactTimeout        time.Duration
@@ -283,8 +284,8 @@ func (s *SQLLog) postCompact() error {
 }
 
 func (s *SQLLog) CurrentRevision(ctx context.Context) (int64, error) {
-	if s.currentRev != 0 {
-		return s.currentRev, nil
+	if currRev := s.currentRev.Load(); currRev != 0 {
+		return currRev, nil
 	}
 	return s.d.CurrentRevision(ctx)
 }
@@ -468,7 +469,7 @@ func (s *SQLLog) startWatch() (chan interface{}, error) {
 }
 
 func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
-	s.currentRev = pollStart
+	s.currentRev.Store(pollStart)
 
 	var (
 		skip        int64
@@ -486,7 +487,7 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 			case <-s.ctx.Done():
 				return
 			case check := <-s.notify:
-				if check <= s.currentRev {
+				if check <= s.currentRev.Load() {
 					continue
 				}
 			case <-wait.C:
@@ -494,7 +495,7 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 		}
 		waitForMore = true
 
-		rows, err := s.d.After(s.ctx, "%", s.currentRev, s.pollBatchSize)
+		rows, err := s.d.After(s.ctx, "%", s.currentRev.Load(), s.pollBatchSize)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				logrus.Errorf("fail to list latest changes: %v", err)
@@ -508,7 +509,7 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 			continue
 		}
 
-		logrus.Tracef("POLL AFTER %d, limit=%d, events=%d", s.currentRev, s.pollBatchSize, len(events))
+		logrus.Tracef("POLL AFTER %d, limit=%d, events=%d", s.currentRev.Load(), s.pollBatchSize, len(events))
 
 		if len(events) == 0 {
 			continue
@@ -516,7 +517,7 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 
 		waitForMore = len(events) < 100
 
-		rev := s.currentRev
+		rev := s.currentRev.Load()
 		var (
 			sequential []*server.Event
 			saveLast   bool
@@ -578,7 +579,7 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 		}
 
 		if saveLast {
-			s.currentRev = rev
+			s.currentRev.Store(rev)
 			if len(sequential) > 0 {
 				result <- sequential
 			}


### PR DESCRIPTION
Go built in race detector found an unsynced read/write.

```
==================
WARNING: DATA RACE
Read at 0x00c000176040 by goroutine 163:
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).CurrentRevision()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:286 +0x44
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).compactor()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:125 +0x13c
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).startWatch.gowrap1()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:463 +0x44

Previous write at 0x00c000176040 by goroutine 164:
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).poll()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:471 +0x64
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).startWatch.gowrap2()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:466 +0x4f

Goroutine 163 (running) created at:
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).startWatch()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:463 +0x312
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).startWatch-fm()
      <autogenerated>:1 +0x33
  github.com/k3s-io/kine/pkg/broadcaster.(*Broadcaster).start()
      /root/src/github.com/kine/kine/pkg/broadcaster/broadcaster.go:53 +0x2f
  github.com/k3s-io/kine/pkg/broadcaster.(*Broadcaster).Subscribe()
      /root/src/github.com/kine/kine/pkg/broadcaster/broadcaster.go:21 +0xf3
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).Watch()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:411 +0x97
  github.com/k3s-io/kine/pkg/logstructured.(*LogStructured).Watch()
      /root/src/github.com/kine/kine/pkg/logstructured/logstructured.go:409 +0x1b2
  github.com/k3s-io/kine/pkg/logstructured.(*LogStructured).ttlEvents.func1()
      /root/src/github.com/kine/kine/pkg/logstructured/logstructured.go:368 +0x304

Goroutine 164 (running) created at:
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).startWatch()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:466 +0x3ec
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).startWatch-fm()
      <autogenerated>:1 +0x33
  github.com/k3s-io/kine/pkg/broadcaster.(*Broadcaster).start()
      /root/src/github.com/kine/kine/pkg/broadcaster/broadcaster.go:53 +0x2f
  github.com/k3s-io/kine/pkg/broadcaster.(*Broadcaster).Subscribe()
      /root/src/github.com/kine/kine/pkg/broadcaster/broadcaster.go:21 +0xf3
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).Watch()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:411 +0x97
  github.com/k3s-io/kine/pkg/logstructured.(*LogStructured).Watch()
      /root/src/github.com/kine/kine/pkg/logstructured/logstructured.go:409 +0x1b2
  github.com/k3s-io/kine/pkg/logstructured.(*LogStructured).ttlEvents.func1()
      /root/src/github.com/kine/kine/pkg/logstructured/logstructured.go:368 +0x304
==================
```