### PR TITLE
Fixing watch race condition around compaction key fixup

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -580,6 +580,12 @@ func (s *SQLLog) poll(result chan interface{}, pollStart int64) {
 		if saveLast {
 			s.currentRev = rev
 			if len(sequential) > 0 {
+				for _, event := range sequential {
+					// fix up apiserver watch with original compact revision key
+					if event.KV.Key == server.CompactRevAPI {
+						event.KV.Key = server.CompactRevKey
+					}
+				}
 				result <- sequential
 			}
 		}

--- a/pkg/server/get.go
+++ b/pkg/server/get.go
@@ -14,10 +14,6 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 	}
 
 	key := string(r.Key)
-	// redirect apiserver get to the substitute compact revision key
-	if key == compactRevKey {
-		key = compactRevAPI
-	}
 
 	rev, kv, err := l.backend.Get(ctx, key, string(r.RangeEnd), r.Limit, r.Revision, r.KeysOnly)
 	logrus.Tracef("GET key=%s, end=%s, revision=%d, currentRev=%d, limit=%d, keysOnly=%v", r.Key, r.RangeEnd, r.Revision, rev, r.Limit, r.KeysOnly)
@@ -25,10 +21,6 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		Header: txnHeader(rev),
 	}
 	if kv != nil {
-		// fix up apiserver get with original compact revision key
-		if kv.Key == compactRevAPI {
-			kv.Key = compactRevKey
-		}
 		resp.Kvs = []*KeyValue{kv}
 		resp.Count = 1
 	}

--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -82,10 +82,6 @@ func toKV(kv *KeyValue) *mvccpb.KeyValue {
 	if kv == nil {
 		return nil
 	}
-	// fix up apiserver watch with original compact revision key
-	if kv.Key == compactRevAPI {
-		kv.Key = compactRevKey
-	}
 	return &mvccpb.KeyValue{
 		Key:            []byte(kv.Key),
 		Value:          kv.Value,

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -10,6 +10,11 @@ import (
 )
 
 var (
+	CompactRevKey = "compact_rev_key"           // key used by apiserver to track compaction, and also used internally by kine for the same purpose
+	CompactRevAPI = "compact_rev_key_apiserver" // key used by kine to store the apiserver's compact_rev_key value
+)
+
+var (
 	ErrNotSupported = status.New(codes.InvalidArgument, "etcdserver: unsupported operations in txn request").Err()
 
 	ErrKeyExists     = rpctypes.ErrGRPCDuplicateKey

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -88,11 +88,6 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 	key := string(r.Key)
 	startRevision := r.StartRevision
 
-	// redirect apiserver watches to the substitute compact revision key
-	if key == compactRevKey {
-		key = compactRevAPI
-	}
-
 	var progressCh chan int64
 	if r.ProgressNotify {
 		progressCh = make(chan int64)


### PR DESCRIPTION
Go built in race detector found a loop variable escape scenario.

```
==================
WARNING: DATA RACE
Write at 0x00c00260d540 by goroutine 481:
  github.com/k3s-io/kine/pkg/server.toKV()
      /root/src/github.com/kine/kine/pkg/server/kv.go:87 +0xf3
  github.com/k3s-io/kine/pkg/server.toEvent()
      /root/src/github.com/kine/kine/pkg/server/watch.go:200 +0x25
  github.com/k3s-io/kine/pkg/server.toEvents()
      /root/src/github.com/kine/kine/pkg/server/watch.go:193 +0xddc
  github.com/k3s-io/kine/pkg/server.(*watcher).Start.func1()
      /root/src/github.com/kine/kine/pkg/server/watch.go:171 +0x781

Previous read at 0x00c00260d540 by goroutine 1930:
  github.com/k3s-io/kine/pkg/logstructured/sqllog.filter()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:437 +0x11e
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).Watch.func1()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:422 +0x12e

Goroutine 481 (running) created at:
  github.com/k3s-io/kine/pkg/server.(*watcher).Start()
      /root/src/github.com/kine/kine/pkg/server/watch.go:104 +0x704
  github.com/k3s-io/kine/pkg/server.(*KVServerBridge).Watch()
      /root/src/github.com/kine/kine/pkg/server/watch.go:51 +0x557
  github.com/k3s-io/kine/pkg/server.(*KVServerBridge).Watch()
      /root/src/github.com/kine/kine/pkg/server/watch.go:45 +0x499
  go.etcd.io/etcd/api/v3/etcdserverpb._Watch_Watch_Handler()
      /root/go/pkg/mod/go.etcd.io/etcd/api/v3@v3.6.4/etcdserverpb/rpc.pb.go:6935 +0xe5
  google.golang.org/grpc.(*Server).processStreamingRPC()
      /root/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1722 +0x1fd7
  google.golang.org/grpc.(*Server).handleStream()
      /root/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1846 +0x1324
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /root/go/pkg/mod/google.golang.org/grpc@v1.75.1/server.go:1061 +0x158

Goroutine 1930 (running) created at:
  github.com/k3s-io/kine/pkg/logstructured/sqllog.(*SQLLog).Watch()
      /root/src/github.com/kine/kine/pkg/logstructured/sqllog/sql.go:419 +0x1cb
  github.com/k3s-io/kine/pkg/logstructured.(*LogStructured).Watch()
      /root/src/github.com/kine/kine/pkg/logstructured/logstructured.go:409 +0x1b2
  github.com/k3s-io/kine/pkg/server.(*watcher).Start.func1()
      /root/src/github.com/kine/kine/pkg/server/watch.go:115 +0x2d4
==================
```