### PR TITLE
Fixing infinite watch init: prefix=/x/y, err=context canceled

### DIFF
--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/k3s-io/kine/pkg/server"
@@ -375,6 +376,8 @@ func (b *Backend) Watch(ctx context.Context, prefix string, startRevision int64)
 			w, err = b.kv.Watch(ctx, prefix, startRevision)
 			if err == nil {
 				break
+			} else if errors.Is(err, context.Canceled) {
+				return
 			}
 			b.l.Warnf("watch init: prefix=%s, err=%s", prefix, err)
 			time.Sleep(time.Second)

--- a/pkg/drivers/nats/kv.go
+++ b/pkg/drivers/nats/kv.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -523,6 +524,9 @@ func NewKeyValue(ctx context.Context, bucket jetstream.KeyValue, js jetstream.Je
 		for {
 			err := kv.btreeWatcher(ctx)
 			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 				logrus.Errorf("btree watcher error: %v", err)
 			}
 		}


### PR DESCRIPTION
If the error is `context canceled` `err == nil` would be never true, so it looks an infinite loop.