### PR TITLE
Fix progress notification with no additional revisions

### DIFF
--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -160,7 +160,7 @@ func (w *watcher) Start(ctx context.Context, r *etcdserverpb.WatchCreateRequest)
 			}
 
 			// send response. note that there are no events if this is a progress response.
-			if revision >= startRevision {
+			if len(events) == 0 || revision >= startRevision {
 				wr := &etcdserverpb.WatchResponse{
 					Header:  txnHeader(revision),
 					WatchId: id,

--- a/pkg/testserver/test_server.go
+++ b/pkg/testserver/test_server.go
@@ -32,6 +32,7 @@ func NewTestConfig(t testing.TB) *embed.Config {
 	clientURL := url.URL{Scheme: "unix", Path: "/tmp/kine.sock"}
 
 	cfg.ListenClientUrls = []url.URL{clientURL}
+	cfg.ExperimentalWatchProgressNotifyInterval = 5 * time.Second
 	cfg.Dir = t.TempDir()
 	os.Chmod(cfg.Dir, 0700)
 	return cfg
@@ -56,6 +57,7 @@ func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
 	config := app.Config(nil)
 	config.WaitGroup = wg
 	config.Listener = cfg.ListenClientUrls[0].String()
+	config.NotifyInterval = cfg.ExperimentalWatchProgressNotifyInterval
 	config.CompactInterval = 0
 	config.CompactMinRetain = 0
 


### PR DESCRIPTION
Fixes test that was only present in older Kubernetes releases.

* ListWatch lists resources, and then starts watching at revision+1
* Watch progress notifications are supposed to periodically send an empty watch response, with current revision set in the header.
* The check of current revision vs watch start revision was preventing the progress notification from being sent when there were no additional writes to move the current revision forward to revision+1

In practice this never actually happens, as there's always a lease renewal or something else going on to increase the revision above the start revision. There are apparently no tests in the Kubernetes 1.34 codebase that cover this, but Kubernetes 1.32 did. 

We were also neglecting to plumb the configured progress interval through from the test's etcd config. The default is 5 seconds so it didn't break anything, but we should do it anyway.


