### PR TITLE
Don't re-enqueue deletion if context is cancelled

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -281,7 +281,7 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 }
 
 func (l *LogStructured) ttl(ctx context.Context) {
-	queue := workqueue.NewDelayingQueue()
+	queue := workqueue.NewTypedDelayingQueue[string]()
 	rwMutex := &sync.RWMutex{}
 	ttlEventKVMap := make(map[string]*ttlEventKV)
 	eventCh := l.ttlEvents(ctx)
@@ -321,7 +321,7 @@ func (l *LogStructured) ttl(ctx context.Context) {
 	}
 }
 
-func (l *LogStructured) handleTTLEvents(ctx context.Context, rwMutex *sync.RWMutex, queue workqueue.DelayingInterface, store map[string]*ttlEventKV) bool {
+func (l *LogStructured) handleTTLEvents(ctx context.Context, rwMutex *sync.RWMutex, queue workqueue.TypedDelayingInterface[string], store map[string]*ttlEventKV) bool {
 	key, shutdown := queue.Get()
 	if shutdown {
 		logrus.Info("TTL events work queue has shut down")
@@ -329,7 +329,7 @@ func (l *LogStructured) handleTTLEvents(ctx context.Context, rwMutex *sync.RWMut
 	}
 	defer queue.Done(key)
 
-	eventKV := loadTTLEventKV(rwMutex, store, key.(string))
+	eventKV := loadTTLEventKV(rwMutex, store, key)
 	if eventKV == nil {
 		logrus.Errorf("TTL event not found for key=%v", key)
 		return true


### PR DESCRIPTION
Fixes error that has been reported on Slack a few times:
> `Oct 28 16:08:49 notice k3s: time="2025-10-28T16:08:49+01:00" level=error msg="TTL delete trigger failed for key=/registry/events/<podname>-59dd494c99-6zccx.18716e967027d1c1: context canceled, requeuing"`

This happens when K3s or RKE2 use kine with TLS - kine is started up once without TLS to extract bootstrap data (the kine certs), and then stopped. Unfortunately the workqueue does not get the memo and keeps running with a cancelled context.

The for loop was only checking for context cancellation once, before going into an endless range on the event channel. Move the channel read into the select, so that the for loop actually runs more than once and checks for cancellation every iteration.

We should also shut down the workqueue if the event channel is closed, as this is another indicator of some problem that should halt processing.

On the processing side, don't reenqueue on context cancellation, as it will never succeed.

Also replaces `workqueue.DelayingInterface` with `workqueue.TypedDelayingInterface[string]` - the untyped version has been deprecated since 1.31, and the typed version saves us an assertion.