### PR TITLE
Backslash-escape underscores in list query LIKE expression

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -49,7 +49,7 @@ var (
 				SELECT MAX(mkv.id) AS id
 				FROM kine AS mkv
 				WHERE
-					mkv.name LIKE ?
+					mkv.name LIKE ? ESCAPE '\'
 					%%s
 				GROUP BY mkv.name) AS maxkv
 				ON maxkv.id = kv.id
@@ -240,7 +240,7 @@ func Open(ctx context.Context, wg *sync.WaitGroup, driverName, dataSourceName st
 			SELECT (%s), (%s), %s
 			FROM kine AS kv
 			WHERE
-				kv.name LIKE ? AND
+				kv.name LIKE ? ESCAPE '\' AND
 				kv.id > ?
 			ORDER BY kv.id ASC`, revSQL, compactRevSQL, withOldVal), paramCharacter, numbered),
 

--- a/pkg/drivers/pgsql/pgsql.go
+++ b/pkg/drivers/pgsql/pgsql.go
@@ -87,7 +87,7 @@ func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, se
 			FROM
 				kine AS kv
 			WHERE
-				kv.name LIKE ? 
+				kv.name LIKE ? ESCAPE '\'
 				%%s
 			ORDER BY kv.name, theid DESC
 		) AS maxkv
@@ -107,7 +107,7 @@ func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, se
 				kv.id AS theid, kv.deleted
 			FROM kine AS kv
 			WHERE
-				kv.name LIKE ?
+				kv.name LIKE ? ESCAPE '\'
 				%s
 			ORDER BY kv.name, theid DESC
 			) AS c

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -74,7 +74,7 @@ func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, re
 }
 
 func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, revision int64, includeDeletes, keysOnly bool) (int64, *server.Event, error) {
-	rev, events, err := l.log.List(ctx, key, rangeEnd, limit, revision, includeDeletes, keysOnly)
+	rev, events, err := l.log.List(ctx, strings.ReplaceAll(key, `_`, `\_`), rangeEnd, limit, revision, includeDeletes, keysOnly)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -188,7 +188,7 @@ func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit
 		startKey = ""
 	}
 
-	rev, events, err := l.log.List(ctx, prefix, startKey, limit, revision, false, keysOnly)
+	rev, events, err := l.log.List(ctx, strings.ReplaceAll(prefix, `_`, `\_`), startKey, limit, revision, false, keysOnly)
 	if err != nil {
 		return rev, nil, err
 	}


### PR DESCRIPTION
Addresses 
* https://github.com/k3s-io/kine/issues/562

Getting/listing resource with underscore in name now works properly - even if these resources cannot be created as underscores are not valid in Kubernetes resource names.

```
time="2025-12-08T19:00:35.780480639Z" level=trace msg="QUERY [/registry/configmaps/default/kube\\_root\\_ca.crt  false] :  SELECT * FROM ( SELECT ( SELECT MAX(rkv.id) AS id FROM kine AS rkv), ( SELECT MAX(crkv.prev_revision) AS prev_revision FROM kine AS crkv WHERE crkv.name = 'compact_rev_key'), kv.id AS theid, kv.name AS thename, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease, kv.value FROM kine AS kv JOIN ( SELECT MAX(mkv.id) AS id FROM kine AS mkv WHERE mkv.name LIKE ? ESCAPE '\\' AND mkv.name >= ? GROUP BY mkv.name) AS maxkv ON maxkv.id = kv.id WHERE kv.deleted = 0 OR ? ) AS lkv ORDER BY lkv.thename ASC LIMIT 1"
time="2025-12-08T19:00:35.781284977Z" level=trace msg="GET /registry/configmaps/default/kube_root_ca.crt, rev=0 => rev=569, kv=false, err=<nil>"
time="2025-12-08T19:00:35.781299739Z" level=trace msg="GET key=/registry/configmaps/default/kube_root_ca.crt, end=, revision=0, currentRev=569, limit=1, keysOnly=false"
```

previously this would match incorrectly (note `kv=true`):

```
time="2025-12-08T19:20:39.286137215Z" level=trace msg="QUERY [/registry/configmaps/default/kube_root_ca.crt  false] :  SELECT * FROM ( SELECT ( SELECT MAX(rkv.id) AS id FROM kine AS rkv), ( SELECT MAX(crkv.prev_revision) AS prev_revision FROM kine AS crkv WHERE crkv.name = 'compact_rev_key'), kv.id AS theid, kv.name AS thename, kv.created, kv.deleted, kv.create_revision, kv.prev_revision, kv.lease, kv.value FROM kine AS kv JOIN ( SELECT MAX(mkv.id) AS id FROM kine AS mkv WHERE mkv.name LIKE ? AND mkv.name >= ? GROUP BY mkv.name) AS maxkv ON maxkv.id = kv.id WHERE kv.deleted = 0 OR ? ) AS lkv ORDER BY lkv.thename ASC LIMIT 1"
time="2025-12-08T19:20:39.287156524Z" level=trace msg="GET /registry/configmaps/default/kube_root_ca.crt, rev=0 => rev=715, kv=true, err=<nil>"
time="2025-12-08T19:20:39.28717826Z" level=trace msg="GET key=/registry/configmaps/default/kube_root_ca.crt, end=, revision=0, currentRev=715, limit=1, keysOnly=false"
```