### PR TITLE
Fix golangci-lint on multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY ./scripts/buildx ./scripts/version ./scripts/
 COPY ./go.mod ./go.sum ./main.go ./
 COPY ./pkg ./pkg
 COPY ./.git ./.git
-COPY ./.golangci.json ./.golangci.json
+COPY ./.golangci.yml ./.golangci.yml
 
 RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     ./scripts/buildx


### PR DESCRIPTION
Fix multi-arch-build step, which is only used by release CI