### PR TITLE
Add support for client cert auth on the etcd endpoints

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -88,6 +88,12 @@ func New() *cli.App {
 			Destination: &config.ServerTLSConfig.KeyFile,
 			EnvVars:     []string{"KINE_SERVER_KEY_FILE"},
 		},
+		&cli.StringFlag{
+			Name:        "trusted-ca-file",
+			Usage:       "CA certificate for verifying client certificates",
+			Destination: &config.ServerTLSConfig.TrustedCAFile,
+			EnvVars:     []string{"KINE_TRUSTED_CA_FILE"},
+		},
 		&cli.IntFlag{
 			Name:        "datastore-max-idle-connections",
 			Usage:       "Maximum number of idle connections retained by datastore. If value = 0, the system default will be used. If value < 0, idle connections will not be reused.",
@@ -222,6 +228,7 @@ func run(c *cli.Context) (rerr error) {
 	if c.Bool("debug") {
 		logrus.SetLevel(logrus.TraceLevel)
 	}
+
 	ctx := signals.SetupSignalContext()
 
 	if !metricsIgnoreTLSConfig {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -256,10 +256,11 @@ func grpcServer(config Config) (*grpc.Server, error) {
 	}
 
 	if config.ServerTLSConfig.CertFile != "" && config.ServerTLSConfig.KeyFile != "" {
-		creds, err := credentials.NewServerTLSFromFile(config.ServerTLSConfig.CertFile, config.ServerTLSConfig.KeyFile)
+		tlsConfig, err := config.ServerTLSConfig.ServerConfig()
 		if err != nil {
 			return nil, err
 		}
+		creds := credentials.NewTLS(tlsConfig)
 		gopts = append(gopts, grpc.Creds(creds))
 	}
 

--- a/pkg/tls/config.go
+++ b/pkg/tls/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Config struct {
-	CAFile     string
-	CertFile   string
-	KeyFile    string
-	SkipVerify bool
+	CAFile        string
+	CertFile      string
+	KeyFile       string
+	SkipVerify    bool
+	TrustedCAFile string
 }
 
 func (c Config) ClientConfig() (*tls.Config, error) {
@@ -25,6 +26,24 @@ func (c Config) ClientConfig() (*tls.Config, error) {
 		InsecureSkipVerify: c.SkipVerify,
 	}
 	tlsConfig, err := info.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return tlsConfig, nil
+}
+
+func (c Config) ServerConfig() (*tls.Config, error) {
+	if c.CertFile == "" && c.KeyFile == "" {
+		return nil, nil
+	}
+
+	info := &transport.TLSInfo{
+		CertFile:      c.CertFile,
+		KeyFile:       c.KeyFile,
+		TrustedCAFile: c.TrustedCAFile,
+	}
+	tlsConfig, err := info.ServerConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds support for basic client cert auth using the same `--trusted-ca-file` flag that ETCD itself uses. I decided to leave the metrics endpoint unauthenticated, but don't have super strong feelings there.

cc #272