### PR TITLE
Reject watch with negative StartRevision

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -287,7 +287,7 @@ func (l *loggingServerStream) SendMsg(m any) error {
 	start := time.Now()
 	defer func() {
 		if wr, ok := m.(*etcdserverpb.WatchResponse); ok {
-			logrus.Tracef("STREAM STATS WATCH SEND DONE id=%d, revision=%d, events=%d, size=%d, time=%s", wr.WatchId, wr.Header.Revision, len(wr.Events), wr.Size(), time.Since(start).Truncate(time.Microsecond))
+			logrus.Tracef("STREAM STATS WATCH SEND DONE id=%d, revision=%d, events=%d, size=%d, reason=%q, time=%s", wr.WatchId, wr.Header.Revision, len(wr.Events), wr.Size(), wr.CancelReason, time.Since(start).Truncate(time.Microsecond))
 			return
 		}
 		if p, ok := m.(proto.Message); ok {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	ErrNotSupported = status.New(codes.InvalidArgument, "etcdserver: unsupported operations in txn request").Err()
+	ErrInvalidWatch = status.New(codes.InvalidArgument, "etcdserver: unsupported options in watch request").Err()
 
 	ErrKeyExists     = rpctypes.ErrGRPCDuplicateKey
 	ErrCompacted     = rpctypes.ErrGRPCCompacted


### PR DESCRIPTION
Matches upstream etcd behavior added in 
* https://github.com/etcd-io/etcd/pull/20693