### PR TITLE
Return actual latest revision in range response header

### DIFF
--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -78,9 +78,6 @@ func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, re
 	if err != nil {
 		return 0, nil, err
 	}
-	if revision != 0 {
-		rev = revision
-	}
 	if len(events) == 0 {
 		return rev, nil, nil
 	}
@@ -202,8 +199,6 @@ func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit
 			return currentRev, nil, err
 		}
 		return l.List(ctx, prefix, startKey, limit, currentRev, keysOnly)
-	} else if revision != 0 {
-		rev = revision
 	}
 
 	kvs := make([]*server.KeyValue, 0, len(events))

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -355,7 +355,7 @@ func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revis
 		return 0, nil, err
 	}
 
-	if revision > 0 && len(result) == 0 {
+	if revision != 0 && len(result) == 0 {
 		// a zero length result won't have the compact or current revisions so get them manually
 		rev, err = s.CurrentRevision(ctx)
 		if err != nil {

--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -19,7 +19,10 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		prefix = prefix + "/"
 	}
 	start := string(r.Key)
-	revision := r.Revision
+	revision := int64(0)
+	if r.Revision > 0 {
+		revision = r.Revision
+	}
 
 	if r.CountOnly {
 		rev, count, err := l.backend.Count(ctx, prefix, start, revision)


### PR DESCRIPTION
Fix issue where lists with revision would return the requested revision as latest in the RangeResponse header, instead of the actual latest revision. Also properly handles negative revisions in range request, which should be handled same as 0:
> All Responses from etcd API have an attached response header which includes cluster metadata for the response:
> * revision - the revision of the key-value store **when generating the response**.
> 
> Keys are fetched from the key-value store using the Range API call, which takes a RangeRequest:
> * revision - the point-in-time of the key-value store to use for the range. **If revision is less or equal to zero, the range is over the latest key-value store**.

This behavior goes back to the very first commit to this project - the lines I'm touching here blame back to the initial commit - but this does not match what etcd does.

I suspect this may be the cause of slow ListWatch clients sometimes throwing "revision has been compacted" errors - the List response header is giving them a stale version to resume Watching from.