### PR TITLE
Improve performance of `util.UntilWithContext`

### DIFF
--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -47,8 +47,8 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 
 	logrus.Tracef("WATCH SERVER CREATE server=%d", w.id)
 
-	go util.UntilWithContext(ws.Context(), s.getProgressReportInterval(), w.ProgressIfSynced)
-	go util.UntilWithContext(ws.Context(), progressResponsePeriod, w.ProgressAll)
+	go util.UntilWithContext(ws.Context(), s.getProgressReportInterval(), w.ProgressIfSynced, false)
+	go util.UntilWithContext(ws.Context(), progressResponsePeriod, w.ProgressAll, false)
 
 	for {
 		msg, err := ws.Recv()


### PR DESCRIPTION
Replace time.After with simple backoff manager for timer reuse

The use of time.After here was causing time.NewTimer to account for 20% of memory allocations by size, and 30% by count