### PR TITLE
Fix `failed to parse compact revision` error after upgrade

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -674,6 +674,10 @@ func scan(rows *sql.Rows, rev *int64, compact *int64, event *server.Event, val, 
 	if event.Create {
 		event.KV.CreateRevision = event.KV.ModRevision
 		event.PrevKV = nil
+	} else {
+		event.PrevKV.CreateRevision = event.KV.CreateRevision
+		event.PrevKV.Lease = event.KV.Lease
+		event.PrevKV.Key = event.KV.Key
 	}
 
 	*compact = c.Int64

--- a/pkg/server/compact.go
+++ b/pkg/server/compact.go
@@ -130,5 +130,5 @@ func DecodeVersion(value []byte) (int64, []byte) {
 		return version, val
 	}
 	version, _ := strconv.ParseInt(string(value), 10, 64)
-	return version, nil
+	return version, []byte("0")
 }

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -229,7 +229,6 @@ func toEvent(event *Event) *mvccpb.Event {
 	} else {
 		e.Type = mvccpb.PUT
 	}
-
 	return e
 }
 


### PR DESCRIPTION
Recent release of kube-apiserver expect the compact_rev_key to contain an int string; unfortunately older releases discarded the value and only kept the revision. We need to return some value that can be parsed as an integer, until the next compact stores a new value.

* Ref: https://github.com/k3s-io/k3s/issues/13650