### PR TITLE
Optimize SQLite driver database size calculation

### DIFF
--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -77,7 +77,7 @@ func NewVariant(ctx context.Context, wg *sync.WaitGroup, driverName string, cfg 
 	}
 
 	dialect.LastInsertID = true
-	dialect.GetSizeSQL = `SELECT SUM(pgsize) FROM dbstat`
+	dialect.GetSizeSQL = `SELECT (page_count - freelist_count) * page_size FROM pragma_page_count(), pragma_freelist_count(), pragma_page_size()`
 	dialect.CompactSQL = `
 		DELETE FROM kine AS kv
 		WHERE

--- a/scripts/build
+++ b/scripts/build
@@ -22,4 +22,4 @@ LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Kine
-CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine
+CGO_CFLAGS="-DSQLITE_USE_ALLOCA=1" go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine

--- a/scripts/buildx
+++ b/scripts/buildx
@@ -28,4 +28,4 @@ LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.Version=$VERSION"
 LINKFLAGS="-X github.com/k3s-io/kine/pkg/version.GitCommit=$COMMIT $LINKFLAGS"
 
 echo Building Multiplatform Kine ${VERSION}
-CGO_CFLAGS="-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1" xx-go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"
+CGO_CFLAGS="-DSQLITE_USE_ALLOCA=1" xx-go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -tags nats -o bin/kine"${OPT_OS}${ARCH}"


### PR DESCRIPTION
Using dbstat is very inefficient and can take several seconds on a large database causing metrics gathering failures on k8s which only wait for up to one second. The true size of an SQLite database can be built by multiplying page count with page size which gives the exact size on disk.

I don't know if there's a reason to use this slower query but based on the original commit 92fcaea9111e2435227d5c70c3c2dc6d91fc82e7 this change might be in the right direction.

```
# time sqlite3 state.db 'SELECT SUM(pgsize) FROM dbstat'
4594323456

real    0m1.692s
user    0m0.756s
sys     0m0.936s
```

```
# time sqlite3 state.db 'SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()'
4722708480

real    0m0.004s
user    0m0.000s
sys     0m0.004s

```

Note that the size on disk matches:
```
# ls -l state.db
-rw-r--r-- 1 root root 4722708480 Mar  4 06:30 state.db
```