### PR TITLE
Add support for remote unix socket addresses

### DIFF
--- a/pkg/drivers/remote/remote.go
+++ b/pkg/drivers/remote/remote.go
@@ -1,4 +1,4 @@
-package http
+package remote
 
 import (
 	"context"
@@ -8,6 +8,8 @@ import (
 	"github.com/k3s-io/kine/pkg/server"
 )
 
+// New returns a driver for a remote grpc socket. Kine will not build a new backend, but will
+// simply pass the connection through to the specified endpoint.
 func New(_ context.Context, _ *sync.WaitGroup, _ *drivers.Config) (leaderElect bool, backend server.Backend, err error) {
 	return true, nil, nil
 }
@@ -15,4 +17,6 @@ func New(_ context.Context, _ *sync.WaitGroup, _ *drivers.Config) (leaderElect b
 func init() {
 	drivers.Register("http", New)
 	drivers.Register("https", New)
+	drivers.Register("unix", New)
+	drivers.Register("unixs", New)
 }

--- a/pkg/endpoint/init.go
+++ b/pkg/endpoint/init.go
@@ -2,9 +2,9 @@ package endpoint
 
 import (
 	// Import all the default drivers
-	_ "github.com/k3s-io/kine/pkg/drivers/http"
 	_ "github.com/k3s-io/kine/pkg/drivers/mysql"
 	_ "github.com/k3s-io/kine/pkg/drivers/nats"
 	_ "github.com/k3s-io/kine/pkg/drivers/pgsql"
+	_ "github.com/k3s-io/kine/pkg/drivers/remote"
 	_ "github.com/k3s-io/kine/pkg/drivers/sqlite"
 )


### PR DESCRIPTION
K3s uses the endpoint package to parse the datastore-endpoint flag, which does not currently support connecting to standalone kine over a unix socket.

This will allow kine to connect to etcd or kine on sockets, in addition to the existing http/https schemes.