### PR TITLE
Add partial index to improve SQLite compact performance

### DIFF
--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -40,6 +40,7 @@ var (
 		`CREATE INDEX IF NOT EXISTS kine_id_deleted_index ON kine (id,deleted)`,
 		`CREATE INDEX IF NOT EXISTS kine_prev_revision_index ON kine (prev_revision)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS kine_name_prev_revision_uindex ON kine (name, prev_revision)`,
+		`CREATE INDEX IF NOT EXISTS kine_id_compact_rev_key_with_prev_revision_index ON kine(id, name, prev_revision) WHERE name != 'compact_rev_key' AND prev_revision != 0`,
 	}
 )
 


### PR DESCRIPTION
The compaction query uses a union that has where conditions which can't be quickly met by any generic index.

These numbers are from a cluster with more than 80 worker nodes and over 60 000 running pods. The Kine state database is about 4.4 GB and performance in general is fine and with #611 there's no complaints about metrics gathering timeouts anymore.

This change will obviously not have major impact on small clusters but in this scale it adds up quickly if a lot of revisions get replaced in quick succession and compaction starts locking out writes.

Without index:
```
time="2026-03-05T07:38:58+01:00" level=info msg="COMPACT deleted 636 rows from 664 revisions in 746.368664ms - compacted to 27545338/27546338"
time="2026-03-05T07:39:59+01:00" level=info msg="COMPACT deleted 648 rows from 656 revisions in 624.883243ms - compacted to 27545994/27546994"
time="2026-03-05T07:41:00+01:00" level=info msg="COMPACT deleted 692 rows from 708 revisions in 715.513544ms - compacted to 27546702/27547702"
time="2026-03-05T07:42:00+01:00" level=info msg="COMPACT deleted 630 rows from 651 revisions in 808.281538ms - compacted to 27547353/27548353"
time="2026-03-05T07:43:01+01:00" level=info msg="COMPACT deleted 636 rows from 643 revisions in 622.248286ms - compacted to 27547996/27548996"
time="2026-03-05T07:44:02+01:00" level=info msg="COMPACT deleted 661 rows from 658 revisions in 610.114915ms - compacted to 27548654/27549654"
time="2026-03-05T07:45:03+01:00" level=info msg="COMPACT deleted 641 rows from 638 revisions in 799.615866ms - compacted to 27549292/27550292"
time="2026-03-05T07:46:04+01:00" level=info msg="COMPACT deleted 638 rows from 638 revisions in 828.795709ms - compacted to 27549930/27550930"
time="2026-03-05T07:47:05+01:00" level=info msg="COMPACT deleted 665 rows from 671 revisions in 673.534383ms - compacted to 27550601/27551601"
time="2026-03-05T07:48:05+01:00" level=info msg="COMPACT deleted 654 rows from 670 revisions in 629.280298ms - compacted to 27551271/27552271"
```

With index:
```
time="2026-03-05T08:52:51+01:00" level=info msg="COMPACT deleted 592 rows from 617 revisions in 223.899355ms - compacted to 27595879/27596879"
time="2026-03-05T08:53:52+01:00" level=info msg="COMPACT deleted 612 rows from 612 revisions in 311.66092ms - compacted to 27596491/27597491"
time="2026-03-05T08:54:52+01:00" level=info msg="COMPACT deleted 628 rows from 628 revisions in 294.26009ms - compacted to 27597119/27598119"
time="2026-03-05T08:55:52+01:00" level=info msg="COMPACT deleted 645 rows from 645 revisions in 213.232753ms - compacted to 27597764/27598764"
time="2026-03-05T08:56:53+01:00" level=info msg="COMPACT deleted 621 rows from 621 revisions in 219.187294ms - compacted to 27598385/27599385"
time="2026-03-05T08:57:53+01:00" level=info msg="COMPACT deleted 650 rows from 640 revisions in 299.188521ms - compacted to 27599025/27600025"
time="2026-03-05T08:58:54+01:00" level=info msg="COMPACT deleted 890 rows from 873 revisions in 287.946612ms - compacted to 27599898/27600898"
time="2026-03-05T08:59:54+01:00" level=info msg="COMPACT deleted 855 rows from 1000 revisions in 227.722191ms - compacted to 27600898/27602680"
time="2026-03-05T09:00:54+01:00" level=info msg="COMPACT deleted 657 rows from 1000 revisions in 235.836524ms - compacted to 27601898/27604419"
time="2026-03-05T09:00:55+01:00" level=info msg="COMPACT deleted 513 rows from 782 revisions in 233.899854ms - compacted to 27602680/27604419"
```

For normal no extra load compaction on this cluster the speedup is roughly 2.5x.