### PR TITLE
Memory Driver

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-        test: [sqlite, litestream, mysql, postgres, cockroachdb, schema-migration, nats, nats-embedded, nats-socket]
+        test: [sqlite, memory, litestream, mysql, postgres, cockroachdb, schema-migration, nats, nats-embedded, nats-socket]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
     - name: Download Artifacts

--- a/pkg/drivers/memory/memory.go
+++ b/pkg/drivers/memory/memory.go
@@ -1,0 +1,535 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/k3s-io/kine/pkg/drivers"
+	"github.com/k3s-io/kine/pkg/server"
+	"github.com/k3s-io/kine/pkg/ttl"
+	"github.com/sirupsen/logrus"
+	"github.com/tidwall/btree"
+)
+
+func init() {
+	drivers.Register("memory", New)
+}
+
+func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, server.Backend, error) {
+	logrus.Info("using in-memory backend")
+	return false, &Memory{
+		keys:     btree.NewMap[string, []*entry](0),
+		notifyCh: make(chan struct{}),
+	}, nil
+}
+
+type entry struct {
+	revision       int64
+	key            string
+	value          []byte
+	createRevision int64
+	version        int64
+	prevRevision   int64
+	lease          int64
+	created        bool
+	deleted        bool
+	prev           *entry
+}
+
+func (e *entry) toKeyValue() *server.KeyValue {
+	return &server.KeyValue{
+		Key:            e.key,
+		Value:          e.value,
+		CreateRevision: e.createRevision,
+		ModRevision:    e.revision,
+		Version:        e.version,
+		Lease:          e.lease,
+	}
+}
+
+type Memory struct {
+	mu              sync.RWMutex
+	currentRevision atomic.Int64
+	compactRevision int64
+
+	log  []*entry
+	keys *btree.Map[string, []*entry]
+
+	notifyMu sync.Mutex
+	notifyCh chan struct{}
+}
+
+// explicit interface check
+var _ server.Backend = &Memory{}
+
+func (m *Memory) Start(ctx context.Context) error {
+	// Seed the same startup entries that SQL-backed and NATS backends do:
+	//   1. compact_rev_key — written by SQLLog.compactStart; gives the backend
+	//      a non-zero starting revision (apiserver rejects rev=0).
+	//   2. /registry/health — written by LogStructured.Start; the apiserver
+	//      uses it as a liveness probe.
+	m.mu.Lock()
+	rev := m.nextRevision()
+	m.appendEntry(&entry{
+		revision:       rev,
+		key:            "compact_rev_key",
+		createRevision: rev,
+		version:        1,
+		created:        true,
+	})
+	rev = m.nextRevision()
+	m.appendEntry(&entry{
+		revision:       rev,
+		key:            "/registry/health",
+		value:          []byte(`{"health":"true"}`),
+		createRevision: rev,
+		version:        1,
+		created:        true,
+	})
+	m.mu.Unlock()
+
+	go ttl.Run(ctx, m)
+	return nil
+}
+
+func (m *Memory) CurrentRevision(ctx context.Context) (int64, error) {
+	return m.currentRevision.Load(), nil
+}
+
+func (m *Memory) DbSize(ctx context.Context) (int64, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var size int64
+	for _, e := range m.log {
+		size += int64(len(e.key) + len(e.value) + 64)
+	}
+	return size, nil
+}
+
+func (m *Memory) WaitForSyncTo(revision int64) {}
+
+// nextRevision allocates and returns the next revision. Increment is
+// atomic; callers still need m.mu (write) when pairing the new revision
+// with an appendEntry, so the log stays in revision order.
+func (m *Memory) nextRevision() int64 {
+	return m.currentRevision.Add(1)
+}
+
+// appendEntry adds e to the log and to its key's history, wiring up
+// e.prev to point at the previous entry for the same key (if any).
+// Caller must hold m.mu (write).
+func (m *Memory) appendEntry(e *entry) {
+	m.log = append(m.log, e)
+	hist, _ := m.keys.Get(e.key)
+	if len(hist) > 0 {
+		e.prev = hist[len(hist)-1]
+	}
+	m.keys.Set(e.key, append(hist, e))
+}
+
+// broadcast wakes every goroutine currently blocked on getNotifyCh.
+// Implemented as close-and-replace rather than sync.Cond.Broadcast so that
+// waiters can select on ctx.Done() alongside the wake — sync.Cond.Wait()
+// can't be combined with context cancellation without a helper goroutine.
+func (m *Memory) broadcast() {
+	m.notifyMu.Lock()
+	close(m.notifyCh)
+	m.notifyCh = make(chan struct{})
+	m.notifyMu.Unlock()
+}
+
+// getNotifyCh returns a channel that will be closed on the next broadcast.
+// Watchers should grab it BEFORE scanning the log so they don't miss a
+// broadcast that fires while they're iterating.
+func (m *Memory) getNotifyCh() <-chan struct{} {
+	m.notifyMu.Lock()
+	ch := m.notifyCh
+	m.notifyMu.Unlock()
+	return ch
+}
+
+// latest returns the most recent entry for key, or nil if none exists.
+// The returned entry may be a tombstone (deleted == true).
+// Caller must hold m.mu (read or write).
+func (m *Memory) latest(key string) *entry {
+	hist, ok := m.keys.Get(key)
+	if !ok || len(hist) == 0 {
+		return nil
+	}
+	return hist[len(hist)-1]
+}
+
+// atRevision returns the entry for key with the highest revision <= revision,
+// or nil if no such entry exists.
+// Caller must hold m.mu (read or write).
+func (m *Memory) atRevision(key string, revision int64) *entry {
+	hist, ok := m.keys.Get(key)
+	if !ok {
+		return nil
+	}
+	var result *entry
+	for _, e := range hist {
+		if e.revision <= revision {
+			result = e
+		} else {
+			break
+		}
+	}
+	return result
+}
+
+// logIndexAfter returns the index of the first log entry with revision > rev.
+// The log is dense and ordered, with m.log[0].revision == m.compactRevision+1,
+// so the index is just rev - m.compactRevision (clamped). For rev values at or
+// below m.compactRevision the result is 0; for rev at or above the highest
+// stored revision the result is len(m.log).
+// Caller must hold m.mu (read or write).
+func (m *Memory) logIndexAfter(rev int64) int {
+	i := rev - m.compactRevision
+	if i < 0 {
+		i = 0
+	}
+	if i > int64(len(m.log)) {
+		i = int64(len(m.log))
+	}
+	return int(i)
+}
+
+// Get returns the current revision and the KeyValue for the given key.
+func (m *Memory) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *server.KeyValue, error) {
+	if strings.HasSuffix(key, "/") && rangeEnd == "" {
+		key = key[:len(key)-1]
+	}
+	rev, kvs, err := m.List(ctx, key, rangeEnd, limit, revision, keysOnly)
+	if err != nil {
+		return rev, nil, err
+	}
+	if len(kvs) == 0 {
+		return rev, nil, nil
+	}
+	return rev, kvs[0], nil
+}
+
+func (m *Memory) Create(ctx context.Context, key string, value []byte, lease int64) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	latest := m.latest(key)
+	if latest != nil && !latest.deleted {
+		return m.currentRevision.Load(), server.ErrKeyExists
+	}
+
+	rev := m.nextRevision()
+	var prevRev int64
+	if latest != nil {
+		prevRev = latest.revision
+	}
+
+	m.appendEntry(&entry{
+		revision:       rev,
+		key:            key,
+		value:          value,
+		createRevision: rev,
+		version:        1,
+		prevRevision:   prevRev,
+		lease:          lease,
+		created:        true,
+	})
+	m.broadcast()
+	return rev, nil
+}
+
+func (m *Memory) Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *server.KeyValue, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	latest := m.latest(key)
+	if latest == nil || latest.deleted {
+		return m.currentRevision.Load(), nil, false, nil
+	}
+	if latest.revision != revision {
+		return m.currentRevision.Load(), latest.toKeyValue(), false, nil
+	}
+
+	rev := m.nextRevision()
+	e := &entry{
+		revision:       rev,
+		key:            key,
+		value:          value,
+		createRevision: latest.createRevision,
+		version:        latest.version + 1,
+		prevRevision:   latest.revision,
+		lease:          lease,
+	}
+	m.appendEntry(e)
+	m.broadcast()
+	return rev, e.toKeyValue(), true, nil
+}
+
+func (m *Memory) Delete(ctx context.Context, key string, revision int64) (int64, *server.KeyValue, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	latest := m.latest(key)
+	if latest == nil || latest.deleted {
+		return m.currentRevision.Load(), nil, false, nil
+	}
+	if revision != 0 && latest.revision != revision {
+		return m.currentRevision.Load(), latest.toKeyValue(), false, nil
+	}
+
+	rev := m.nextRevision()
+	m.appendEntry(&entry{
+		revision:       rev,
+		key:            key,
+		value:          latest.value,
+		createRevision: latest.createRevision,
+		version:        latest.version,
+		prevRevision:   latest.revision,
+		lease:          latest.lease,
+		deleted:        true,
+	})
+	m.broadcast()
+	return rev, latest.toKeyValue(), true, nil
+}
+
+func (m *Memory) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (int64, []*server.KeyValue, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	rev := m.currentRevision.Load()
+	if revision > 0 {
+		if revision > rev {
+			return rev, nil, server.ErrFutureRev
+		}
+		if revision < m.compactRevision {
+			return rev, nil, server.ErrCompacted
+		}
+		rev = revision
+	}
+
+	seek, exact := seekKey(prefix, startKey)
+	iter := m.keys.Iter()
+	if !iter.Seek(seek) {
+		return rev, nil, nil
+	}
+
+	var kvs []*server.KeyValue
+	for {
+		k := iter.Key()
+		if exact && k != seek {
+			break
+		}
+		if !strings.HasPrefix(k, prefix) {
+			break
+		}
+
+		var e *entry
+		if revision > 0 {
+			e = m.atRevision(k, revision)
+		} else {
+			e = m.latest(k)
+		}
+
+		if e != nil && !e.deleted {
+			kv := e.toKeyValue()
+			if keysOnly {
+				kv.Value = nil
+			}
+			kvs = append(kvs, kv)
+		}
+
+		if !iter.Next() {
+			break
+		}
+	}
+	return rev, kvs, nil
+}
+
+func (m *Memory) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error) {
+	rev, kvs, err := m.List(ctx, prefix, startKey, 0, revision, true)
+	if err != nil {
+		return rev, 0, err
+	}
+	return rev, int64(len(kvs)), nil
+}
+
+func (m *Memory) Watch(ctx context.Context, prefix string, startRevision int64) server.WatchResult {
+	m.mu.RLock()
+	compactRev := m.compactRevision
+	m.mu.RUnlock()
+	rev := m.currentRevision.Load()
+
+	events := make(chan []*server.Event, 100)
+
+	if startRevision > 0 && startRevision <= compactRev {
+		close(events)
+		return server.WatchResult{
+			CurrentRevision: rev,
+			CompactRevision: compactRev,
+			Events:          events,
+		}
+	}
+
+	go func() {
+		defer close(events)
+
+		// lastSeen is the highest revision already delivered to the caller.
+		// Subsequent passes start from the first log entry whose revision is
+		// greater than lastSeen, looked up via logIndexAfter — direct array
+		// indexing by revision no longer holds once compaction trims m.log.
+		lastSeen := startRevision - 1
+		if lastSeen < 0 {
+			lastSeen = rev
+		}
+
+		for {
+			notifyCh := m.getNotifyCh()
+
+			m.mu.RLock()
+			var batch []*server.Event
+			for i := m.logIndexAfter(lastSeen); i < len(m.log); i++ {
+				e := m.log[i]
+				if !strings.HasPrefix(e.key, prefix) {
+					lastSeen = e.revision
+					continue
+				}
+
+				event := &server.Event{
+					Create: e.created,
+					Delete: e.deleted,
+					KV:     e.toKeyValue(),
+					PrevKV: &server.KeyValue{ModRevision: e.prevRevision},
+				}
+				if e.prev != nil {
+					event.PrevKV = e.prev.toKeyValue()
+				}
+
+				batch = append(batch, event)
+				lastSeen = e.revision
+			}
+			m.mu.RUnlock()
+
+			if len(batch) > 0 {
+				select {
+				case events <- batch:
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			select {
+			case <-notifyCh:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	watchRev := startRevision
+	if watchRev <= 0 {
+		watchRev = rev
+	}
+
+	return server.WatchResult{
+		CurrentRevision: watchRev,
+		Events:          events,
+	}
+}
+
+// Compact discards events below the given revision. The log slice is trimmed
+// to entries with revision > the compact target — events at or below the
+// boundary are no longer accessible to watchers. Per-key history in m.keys is
+// trimmed to its floor (the latest entry with revision <= the target) so that
+// reads at the compact boundary still resolve to the correct value; if that
+// floor is a tombstone the entire key history is removed. Entries with
+// revision > the compact target are always retained.
+func (m *Memory) Compact(ctx context.Context, revision int64) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rev := m.currentRevision.Load()
+	if revision > rev {
+		return rev, nil
+	}
+	if revision <= m.compactRevision {
+		return rev, nil
+	}
+
+	var toRemove []string
+
+	m.keys.Scan(func(key string, hist []*entry) bool {
+		floorIdx := -1
+		for i, e := range hist {
+			if e.revision <= revision {
+				floorIdx = i
+			} else {
+				break
+			}
+		}
+
+		var newHist []*entry
+		switch {
+		case floorIdx < 0:
+			// No entry at or below the compact boundary; keep everything.
+			newHist = hist
+		case hist[floorIdx].deleted:
+			// Floor is a tombstone — drop it and everything before; readers
+			// at the compact boundary correctly see the key as absent.
+			newHist = hist[floorIdx+1:]
+		default:
+			newHist = hist[floorIdx:]
+		}
+
+		if len(newHist) == 0 {
+			toRemove = append(toRemove, key)
+		} else if len(newHist) != len(hist) {
+			// The new first entry's predecessor is being dropped; clear the
+			// pointer so the dropped entry can be garbage collected.
+			newHist[0].prev = nil
+			m.keys.Set(key, newHist)
+		}
+		return true
+	})
+
+	for _, k := range toRemove {
+		m.keys.Delete(k)
+	}
+
+	// Trim the log. Because the log is dense and ordered by revision, the cut
+	// point is just (revision - oldCompactRevision); everything before it has
+	// revision <= the target and is no longer reachable via Watch.
+	cut := int(revision - m.compactRevision)
+	if cut > len(m.log) {
+		cut = len(m.log)
+	}
+	for i := 0; i < cut; i++ {
+		m.log[i] = nil
+	}
+	m.log = m.log[cut:]
+
+	m.compactRevision = revision
+	return rev, nil
+}
+
+// seekKey returns the BTree seek target for a List/Range query and a flag
+// indicating whether the iteration should match the seek key exactly. When
+// startKey is empty (or equal to prefix), iteration begins at prefix; if
+// prefix has no trailing slash this is treated as an exact-key lookup.
+// Otherwise startKey is normalized into the prefix's namespace and used as
+// the resume point for paginated range scans.
+func seekKey(prefix, startKey string) (string, bool) {
+	exact := !strings.HasSuffix(prefix, "/") && startKey == ""
+	if startKey == "" || startKey == prefix {
+		return prefix, exact
+	}
+	base := strings.TrimSuffix(prefix, "/")
+	startKey = strings.TrimPrefix(startKey, base)
+	startKey = strings.TrimPrefix(startKey, "/")
+	if startKey != "" {
+		return base + "/" + startKey, false
+	}
+	return prefix, exact
+}

--- a/pkg/drivers/memory/memory_test.go
+++ b/pkg/drivers/memory/memory_test.go
@@ -1,0 +1,698 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/k3s-io/kine/pkg/server"
+	"github.com/k3s-io/kine/pkg/ttl"
+	"github.com/tidwall/btree"
+)
+
+//revive:disable:unhandled-error
+
+func noErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func expEqualErr(t *testing.T, want, got error) {
+	t.Helper()
+	if !errors.Is(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func expEqual[T comparable](t *testing.T, want, got T) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func expSortedKeys(t *testing.T, ents []*server.KeyValue) {
+	t.Helper()
+	var prev string
+	for _, ent := range ents {
+		if prev != "" && prev > ent.Key {
+			t.Fatalf("keys not sorted: %s > %s", prev, ent.Key)
+		}
+		prev = ent.Key
+	}
+}
+
+func expEqualKeys(t *testing.T, want []string, got []*server.KeyValue) {
+	t.Helper()
+	expEqual(t, len(want), len(got))
+	for i, k := range want {
+		expEqual(t, k, got[i].Key)
+	}
+}
+
+func setupBackend(t *testing.T) (*Memory, context.Context) {
+	t.Helper()
+	b := &Memory{
+		keys:     btree.NewMap[string, []*entry](0),
+		notifyCh: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	// Skip Start() to avoid the production seed entries (compact_rev_key,
+	// /registry/health) so tests can assert exact revision values.
+	go ttl.Run(ctx, b)
+	return b, ctx
+}
+
+func TestCreate(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, err := b.Create(ctx, "/test/a", []byte("val-a"), 0)
+	noErr(t, err)
+	expEqual(t, int64(1), rev)
+
+	_, err = b.Create(ctx, "/test/a", []byte("val-a"), 0)
+	expEqualErr(t, server.ErrKeyExists, err)
+
+	rev, err = b.Create(ctx, "/test/a/b", nil, 0)
+	noErr(t, err)
+	expEqual(t, int64(2), rev)
+
+	rev, err = b.Create(ctx, "/test/a/b/c", nil, 0)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+
+	_, count, err := b.Count(ctx, "/test/", "", 0)
+	noErr(t, err)
+	expEqual(t, int64(3), count)
+}
+
+func TestCreateAfterDelete(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, err := b.Create(ctx, "/test/a", []byte("v1"), 0)
+	noErr(t, err)
+
+	_, _, ok, err := b.Delete(ctx, "/test/a", rev)
+	noErr(t, err)
+	expEqual(t, true, ok)
+
+	rev, err = b.Create(ctx, "/test/a", []byte("v2"), 0)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+
+	_, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, "v2", string(kv.Value))
+	expEqual(t, int64(3), kv.CreateRevision)
+	expEqual(t, int64(1), kv.Version)
+}
+
+func TestGet(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	_, err := b.Create(ctx, "/test/a", []byte("b"), 5)
+	noErr(t, err)
+
+	rev, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(1), rev)
+	expEqual(t, "/test/a", kv.Key)
+	expEqual(t, "b", string(kv.Value))
+	expEqual(t, int64(5), kv.Lease)
+	expEqual(t, int64(1), kv.ModRevision)
+	expEqual(t, int64(1), kv.CreateRevision)
+
+	_, kv, err = b.Get(ctx, "/test/nonexistent", "", 0, 0, false)
+	noErr(t, err)
+	if kv != nil {
+		t.Fatal("expected nil for nonexistent key")
+	}
+
+	_, _, err = b.Get(ctx, "/test/a", "", 0, 20, false)
+	expEqualErr(t, server.ErrFutureRev, err)
+}
+
+func TestGetAtRevision(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev1, err := b.Create(ctx, "/test/a", []byte("v1"), 0)
+	noErr(t, err)
+
+	_, _, _, err = b.Update(ctx, "/test/a", []byte("v2"), rev1, 0)
+	noErr(t, err)
+
+	rev, kv, err := b.Get(ctx, "/test/a", "", 0, rev1, false)
+	noErr(t, err)
+	expEqual(t, rev1, rev)
+	expEqual(t, "v1", string(kv.Value))
+
+	rev, kv, err = b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(2), rev)
+	expEqual(t, "v2", string(kv.Value))
+}
+
+func TestUpdate(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, err := b.Create(ctx, "/test/a", []byte("b"), 1)
+	noErr(t, err)
+	expEqual(t, int64(1), rev)
+
+	rev, kv, ok, err := b.Update(ctx, "/test/a", []byte("c"), rev, 0)
+	noErr(t, err)
+	expEqual(t, int64(2), rev)
+	expEqual(t, true, ok)
+	expEqual(t, "/test/a", kv.Key)
+	expEqual(t, "c", string(kv.Value))
+	expEqual(t, int64(0), kv.Lease)
+	expEqual(t, int64(2), kv.ModRevision)
+	expEqual(t, int64(1), kv.CreateRevision)
+	expEqual(t, int64(2), kv.Version)
+
+	rev, kv, ok, err = b.Update(ctx, "/test/a", []byte("d"), rev, 3)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+	expEqual(t, true, ok)
+	expEqual(t, "d", string(kv.Value))
+	expEqual(t, int64(3), kv.Lease)
+	expEqual(t, int64(1), kv.CreateRevision)
+	expEqual(t, int64(3), kv.Version)
+
+	// Wrong revision.
+	rev, _, ok, err = b.Update(ctx, "/test/a", []byte("e"), 1, 0)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+	expEqual(t, false, ok)
+
+	// Nonexistent key.
+	_, _, ok, err = b.Update(ctx, "/test/nope", []byte("e"), 1, 0)
+	noErr(t, err)
+	expEqual(t, false, ok)
+}
+
+func TestDelete(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, err := b.Create(ctx, "/test/a", []byte("b"), 1)
+	noErr(t, err)
+	expEqual(t, int64(1), rev)
+
+	rev, kv, ok, err := b.Delete(ctx, "/test/a", int64(1))
+	noErr(t, err)
+	expEqual(t, int64(2), rev)
+	expEqual(t, true, ok)
+	expEqual(t, "/test/a", kv.Key)
+	expEqual(t, "b", string(kv.Value))
+	expEqual(t, int64(1), kv.Lease)
+	expEqual(t, int64(1), kv.ModRevision)
+	expEqual(t, int64(1), kv.CreateRevision)
+
+	// Already deleted.
+	_, _, ok, err = b.Delete(ctx, "/test/a", 0)
+	noErr(t, err)
+	expEqual(t, false, ok)
+
+	// Re-create and try wrong revision.
+	rev, err = b.Create(ctx, "/test/a", []byte("b"), 0)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+
+	_, _, ok, err = b.Delete(ctx, "/test/a", 1)
+	noErr(t, err)
+	expEqual(t, false, ok)
+
+	// Force delete (revision=0).
+	rev, _, ok, err = b.Delete(ctx, "/test/a", 0)
+	noErr(t, err)
+	expEqual(t, int64(4), rev)
+	expEqual(t, true, ok)
+}
+
+func TestList(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	b.Create(ctx, "/test/a/b/c", nil, 0)
+	b.Create(ctx, "/test/a", nil, 0)
+	b.Create(ctx, "/test/b", nil, 0)
+	b.Create(ctx, "/test/a/b", nil, 0)
+	b.Create(ctx, "/test/c", nil, 0)
+	b.Create(ctx, "/test/d/a", nil, 0)
+	b.Create(ctx, "/test/d/b", nil, 0)
+
+	// All keys under prefix.
+	rev, ents, err := b.List(ctx, "/test/", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(7), rev)
+	expEqual(t, 7, len(ents))
+	expSortedKeys(t, ents)
+
+	// Prefix sub-tree.
+	rev, ents, err = b.List(ctx, "/test/a", "/test/a", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(7), rev)
+	expEqual(t, 3, len(ents))
+	expSortedKeys(t, ents)
+
+	// Start key.
+	rev, ents, err = b.List(ctx, "/test/", "/test/b", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(7), rev)
+	expEqual(t, 4, len(ents))
+	expSortedKeys(t, ents)
+
+	// At a revision.
+	rev, ents, err = b.List(ctx, "/test/", "", 0, 3, false)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+	expEqual(t, 3, len(ents))
+	expSortedKeys(t, ents)
+	expEqualKeys(t, []string{"/test/a", "/test/a/b/c", "/test/b"}, ents)
+
+	// Full list with limit (kine returns full set, pagination handled upstream).
+	rev, ents, err = b.List(ctx, "/test/", "", 4, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(7), rev)
+	expEqual(t, 7, len(ents))
+	expSortedKeys(t, ents)
+	expEqualKeys(t, []string{"/test/a", "/test/a/b", "/test/a/b/c", "/test/b", "/test/c", "/test/d/a", "/test/d/b"}, ents)
+
+	// Start key with range.
+	rev, ents, err = b.List(ctx, "/test/", "/test/c", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(7), rev)
+	expEqual(t, 3, len(ents))
+	expSortedKeys(t, ents)
+	expEqualKeys(t, []string{"/test/c", "/test/d/a", "/test/d/b"}, ents)
+}
+
+func TestListExcludesDeleted(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, _ := b.Create(ctx, "/test/a", []byte("val"), 0)
+	b.Create(ctx, "/test/b", []byte("val"), 0)
+	b.Delete(ctx, "/test/a", rev)
+
+	_, ents, err := b.List(ctx, "/test/", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, 1, len(ents))
+	expEqual(t, "/test/b", ents[0].Key)
+}
+
+func TestCount(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	b.Create(ctx, "/test/a", nil, 0)
+	b.Create(ctx, "/test/b", nil, 0)
+	b.Create(ctx, "/test/c", nil, 0)
+
+	rev, count, err := b.Count(ctx, "/test/", "", 0)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+	expEqual(t, int64(3), count)
+
+	// Count at an earlier revision.
+	_, count, err = b.Count(ctx, "/test/", "", 2)
+	noErr(t, err)
+	expEqual(t, int64(2), count)
+}
+
+func TestWatch(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev1, _ := b.Create(ctx, "/test/a", nil, 0)
+	rev2, _ := b.Create(ctx, "/test/a/1", nil, 0)
+	b.Update(ctx, "/test/a", nil, rev1, 0)
+	b.Delete(ctx, "/test/a", int64(3))
+	b.Update(ctx, "/test/a/1", nil, rev2, 0)
+
+	// Watch all events from the beginning.
+	wctx, cancel := context.WithCancel(ctx)
+	wr := b.Watch(wctx, "/", 1)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	var events []*server.Event
+	for es := range wr.Events {
+		events = append(events, es...)
+	}
+	expEqual(t, 5, len(events))
+
+	// Watch filtered by prefix.
+	wctx, cancel = context.WithCancel(ctx)
+	wr = b.Watch(wctx, "/test/a/", 1)
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	events = nil
+	for es := range wr.Events {
+		events = append(events, es...)
+	}
+	expEqual(t, 2, len(events))
+}
+
+func TestWatchNewEvents(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	wr := b.Watch(wctx, "/test/", 0)
+
+	// Write after watch starts.
+	b.Create(ctx, "/test/a", []byte("hello"), 0)
+
+	select {
+	case events := <-wr.Events:
+		expEqual(t, 1, len(events))
+		expEqual(t, "/test/a", events[0].KV.Key)
+		expEqual(t, true, events[0].Create)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch event")
+	}
+}
+
+func TestWatchPrevKV(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, _ := b.Create(ctx, "/test/a", []byte("v1"), 0)
+
+	wctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	wr := b.Watch(wctx, "/test/", 0)
+
+	b.Update(ctx, "/test/a", []byte("v2"), rev, 0)
+
+	select {
+	case events := <-wr.Events:
+		expEqual(t, 1, len(events))
+		expEqual(t, "v2", string(events[0].KV.Value))
+		expEqual(t, "v1", string(events[0].PrevKV.Value))
+		expEqual(t, int64(1), events[0].PrevKV.ModRevision)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watch event")
+	}
+}
+
+func TestCompact(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	b.Create(ctx, "/test/a", nil, 0)
+	b.Create(ctx, "/test/b", nil, 0)
+	b.Create(ctx, "/test/c", nil, 0)
+
+	rev, err := b.Compact(ctx, 2)
+	noErr(t, err)
+	expEqual(t, int64(3), rev)
+
+	// List at compacted revision should fail.
+	_, _, err = b.List(ctx, "/test/", "", 0, 1, false)
+	expEqualErr(t, server.ErrCompacted, err)
+
+	// List at current revision should work.
+	_, ents, err := b.List(ctx, "/test/", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, 3, len(ents))
+
+	// List at the compact boundary should work.
+	_, ents, err = b.List(ctx, "/test/", "", 0, 2, false)
+	noErr(t, err)
+	expEqual(t, 2, len(ents))
+}
+
+func TestCompactTrimsHistory(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev1, _ := b.Create(ctx, "/test/a", []byte("v1"), 0)
+	b.Create(ctx, "/test/b", []byte("v1"), 0)
+	rev3, _, _, _ := b.Update(ctx, "/test/a", []byte("v2"), rev1, 0)
+	b.Update(ctx, "/test/a", []byte("v3"), rev3, 0)
+	// 4 log entries, /test/a has 3 versions, /test/b has 1.
+
+	if got := len(b.log); got != 4 {
+		t.Fatalf("log length before compact: got %d, want 4", got)
+	}
+
+	if _, err := b.Compact(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	// After compact at rev 4 every log entry is at-or-below the boundary, so
+	// the log is fully trimmed. Per-key history in m.keys still holds each
+	// key's floor entry so reads at the compact boundary resolve correctly.
+	if got := len(b.log); got != 0 {
+		t.Fatalf("log length after compact: got %d, want 0", got)
+	}
+	histA, _ := b.keys.Get("/test/a")
+	if got := len(histA); got != 1 {
+		t.Fatalf("/test/a history after compact: got %d, want 1", got)
+	}
+	histB, _ := b.keys.Get("/test/b")
+	if got := len(histB); got != 1 {
+		t.Fatalf("/test/b history after compact: got %d, want 1", got)
+	}
+
+	// Latest values are still readable at the current revision.
+	_, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, "v3", string(kv.Value))
+
+	// Calling Compact at a rev <= current compactRevision is a no-op.
+	if _, err := b.Compact(ctx, 2); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(b.log); got != 0 {
+		t.Fatalf("log length after no-op compact: got %d, want 0", got)
+	}
+}
+
+func TestCompactDropsTombstones(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev1, _ := b.Create(ctx, "/test/a", []byte("v1"), 0)
+	b.Create(ctx, "/test/b", []byte("v1"), 0)
+	b.Delete(ctx, "/test/a", rev1)
+	// Log: create a (1), create b (2), delete a (3).
+
+	if _, err := b.Compact(ctx, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	// /test/a's tombstone at rev 3 is at-or-below the compact boundary,
+	// so the entire history should be removed.
+	if _, ok := b.keys.Get("/test/a"); ok {
+		t.Fatal("expected /test/a to be removed after compacting tombstone")
+	}
+	// /test/b's floor is its create at rev 2, kept in m.keys.
+	histB, ok := b.keys.Get("/test/b")
+	if !ok || len(histB) != 1 {
+		t.Fatalf("/test/b history after compact: got %v, want 1 entry", histB)
+	}
+	// Every log entry was at-or-below the boundary, so the log is fully trimmed.
+	if got := len(b.log); got != 0 {
+		t.Fatalf("log length after compact: got %d, want 0", got)
+	}
+}
+
+func TestCompactStraddlesBoundary(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	b.Create(ctx, "/test/a", []byte("v1"), 0) // rev 1
+	b.Create(ctx, "/test/b", []byte("v1"), 0) // rev 2
+	b.Create(ctx, "/test/c", []byte("v1"), 0) // rev 3
+	b.Create(ctx, "/test/d", []byte("v1"), 0) // rev 4
+	b.Create(ctx, "/test/e", []byte("v1"), 0) // rev 5
+
+	if got := len(b.log); got != 5 {
+		t.Fatalf("log length before compact: got %d, want 5", got)
+	}
+
+	if _, err := b.Compact(ctx, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Log keeps entries strictly above compactRev: rev 4 and rev 5.
+	if got := len(b.log); got != 2 {
+		t.Fatalf("log length after compact(3): got %d, want 2", got)
+	}
+	if got := b.log[0].revision; got != 4 {
+		t.Fatalf("log[0].revision: got %d, want 4", got)
+	}
+	if got := b.log[1].revision; got != 5 {
+		t.Fatalf("log[1].revision: got %d, want 5", got)
+	}
+
+	// logIndexAfter math is anchored at compactRev+1 = 4.
+	if got := b.logIndexAfter(3); got != 0 {
+		t.Fatalf("logIndexAfter(3): got %d, want 0", got)
+	}
+	if got := b.logIndexAfter(4); got != 1 {
+		t.Fatalf("logIndexAfter(4): got %d, want 1", got)
+	}
+	if got := b.logIndexAfter(5); got != 2 {
+		t.Fatalf("logIndexAfter(5): got %d, want 2", got)
+	}
+}
+
+func TestWatchCompacted(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	b.Create(ctx, "/test/a", nil, 0)
+	b.Create(ctx, "/test/b", nil, 0)
+	b.Compact(ctx, 2)
+
+	wr := b.Watch(ctx, "/test/", 1)
+	expEqual(t, int64(2), wr.CompactRevision)
+
+	// Events channel should be closed immediately.
+	_, ok := <-wr.Events
+	expEqual(t, false, ok)
+}
+
+func TestCurrentRevision(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, err := b.CurrentRevision(ctx)
+	noErr(t, err)
+	expEqual(t, int64(0), rev)
+
+	b.Create(ctx, "/test/a", nil, 0)
+
+	rev, err = b.CurrentRevision(ctx)
+	noErr(t, err)
+	expEqual(t, int64(1), rev)
+}
+
+func TestDbSize(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	size, err := b.DbSize(ctx)
+	noErr(t, err)
+	expEqual(t, int64(0), size)
+
+	b.Create(ctx, "/test/a", []byte("some data"), 0)
+
+	size, err = b.DbSize(ctx)
+	noErr(t, err)
+	if size <= 0 {
+		t.Fatal("expected positive db size")
+	}
+}
+
+func TestKeysOnly(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	b.Create(ctx, "/test/a", []byte("value-a"), 0)
+	b.Create(ctx, "/test/b", []byte("value-b"), 0)
+
+	_, ents, err := b.List(ctx, "/test/", "", 0, 0, true)
+	noErr(t, err)
+	expEqual(t, 2, len(ents))
+	for _, kv := range ents {
+		if kv.Value != nil {
+			t.Fatalf("expected nil value for keysOnly, got %q", kv.Value)
+		}
+	}
+}
+
+func TestVersionIncrement(t *testing.T) {
+	b, ctx := setupBackend(t)
+
+	rev, _ := b.Create(ctx, "/test/a", []byte("v1"), 0)
+
+	_, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(1), kv.Version)
+
+	rev, _, _, _ = b.Update(ctx, "/test/a", []byte("v2"), rev, 0)
+	_, kv, err = b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(2), kv.Version)
+
+	b.Update(ctx, "/test/a", []byte("v3"), rev, 0)
+	_, kv, err = b.Get(ctx, "/test/a", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, int64(3), kv.Version)
+}
+
+// TestTTLExpiration creates 10 keys with leases spread across a ~30 second
+// window and verifies the TTL goroutine deletes each one after its lease
+// elapses. This exercises the workqueue + watch driven expiration path.
+func TestTTLExpiration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running TTL test in -short mode")
+	}
+
+	b, ctx := setupBackend(t)
+
+	type seeded struct {
+		key   string
+		lease int64
+	}
+	leases := []int64{2, 4, 6, 9, 12, 15, 18, 22, 25, 28}
+	keys := make([]seeded, 0, len(leases))
+
+	start := time.Now()
+	for i, lease := range leases {
+		key := fmt.Sprintf("/test/lease-%02d", i)
+		_, err := b.Create(ctx, key, []byte("v"), lease)
+		noErr(t, err)
+		keys = append(keys, seeded{key, lease})
+	}
+
+	// All keys should be present immediately after creation.
+	_, ents, err := b.List(ctx, "/test/", "", 0, 0, false)
+	noErr(t, err)
+	expEqual(t, len(leases), len(ents))
+
+	// Each key should be deleted shortly after its lease elapses. We poll up
+	// to a small grace period after the deadline to absorb workqueue
+	// scheduling latency, and assert that other keys whose leases have not
+	// yet elapsed are still present.
+	const grace = 3 * time.Second
+	for i, k := range keys {
+		deadline := start.Add(time.Duration(k.lease)*time.Second + grace)
+		for {
+			_, kv, err := b.Get(ctx, k.key, "", 0, 0, false)
+			noErr(t, err)
+			if kv == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("key %s with lease=%ds still present %v after creation",
+					k.key, k.lease, time.Since(start))
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		// Keys with later leases should still be alive — only ones we have
+		// already passed the deadline for are allowed to be gone.
+		for j := i + 1; j < len(keys); j++ {
+			next := keys[j]
+			elapsed := time.Since(start)
+			if elapsed >= time.Duration(next.lease)*time.Second {
+				continue
+			}
+			_, kv, err := b.Get(ctx, next.key, "", 0, 0, false)
+			noErr(t, err)
+			if kv == nil {
+				t.Fatalf("key %s with lease=%ds removed prematurely at %v",
+					next.key, next.lease, elapsed)
+			}
+		}
+	}
+
+	// After the longest lease has expired plus a grace period, nothing
+	// should remain under /test/.
+	_, ents, err = b.List(ctx, "/test/", "", 0, 0, false)
+	noErr(t, err)
+	if len(ents) != 0 {
+		t.Fatalf("expected /test/ to be empty after all leases expired, got %d keys", len(ents))
+	}
+}

--- a/pkg/endpoint/init.go
+++ b/pkg/endpoint/init.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	// Import all the default drivers
+	_ "github.com/k3s-io/kine/pkg/drivers/memory"
 	_ "github.com/k3s-io/kine/pkg/drivers/mysql"
 	_ "github.com/k3s-io/kine/pkg/drivers/nats"
 	_ "github.com/k3s-io/kine/pkg/drivers/pgsql"

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/k3s-io/kine/pkg/server"
-)
-
-const (
-	retryInterval = 250 * time.Millisecond
+	"github.com/k3s-io/kine/pkg/ttl"
 )
 
 type Log interface {
@@ -29,12 +23,6 @@ type Log interface {
 	DbSize(ctx context.Context) (int64, error)
 	Compact(ctx context.Context, revision int64) (int64, error)
 	WaitForSyncTo(revision int64)
-}
-
-type ttlEventKV struct {
-	key         string
-	modRevision int64
-	expiredAt   time.Time
 }
 
 type LogStructured struct {
@@ -57,7 +45,7 @@ func (l *LogStructured) Start(ctx context.Context) error {
 			logrus.Errorf("Failed to create health check key: %v", err)
 		}
 	}
-	go l.ttl(ctx)
+	go ttl.Run(ctx, l)
 	return nil
 }
 
@@ -276,143 +264,6 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 
 	updateEvent.KV.ModRevision = rev
 	return rev, updateEvent.KV, true, err
-}
-
-func (l *LogStructured) ttl(ctx context.Context) {
-	queue := workqueue.NewTypedDelayingQueue[string]()
-	rwMutex := &sync.RWMutex{}
-	ttlEventKVMap := make(map[string]*ttlEventKV)
-	eventCh := l.ttlEvents(ctx)
-
-	go func() {
-		for l.handleTTLEvents(ctx, rwMutex, queue, ttlEventKVMap) {
-		}
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			queue.ShutDown()
-			return
-		case event, ok := <-eventCh:
-			if !ok {
-				queue.ShutDown()
-				return
-			}
-			if event.Delete {
-				continue
-			}
-
-			eventKV := loadTTLEventKV(rwMutex, ttlEventKVMap, event.KV.Key)
-			if eventKV == nil {
-				expires := storeTTLEventKV(rwMutex, ttlEventKVMap, event.KV)
-				logrus.Tracef("TTL add event key=%v, modRev=%v, ttl=%v", event.KV.Key, event.KV.ModRevision, expires)
-				queue.AddAfter(event.KV.Key, expires)
-			} else {
-				if event.KV.ModRevision > eventKV.modRevision {
-					expires := storeTTLEventKV(rwMutex, ttlEventKVMap, event.KV)
-					logrus.Tracef("TTL update event key=%v, modRev=%v, ttl=%v", event.KV.Key, event.KV.ModRevision, expires)
-					queue.AddAfter(event.KV.Key, expires)
-				}
-			}
-		}
-	}
-}
-
-func (l *LogStructured) handleTTLEvents(ctx context.Context, rwMutex *sync.RWMutex, queue workqueue.TypedDelayingInterface[string], store map[string]*ttlEventKV) bool {
-	key, shutdown := queue.Get()
-	if shutdown {
-		logrus.Info("TTL events work queue has shut down")
-		return false
-	}
-	defer queue.Done(key)
-
-	eventKV := loadTTLEventKV(rwMutex, store, key)
-	if eventKV == nil {
-		logrus.Errorf("TTL event not found for key=%v", key)
-		return true
-	}
-
-	if expires := time.Until(eventKV.expiredAt); expires > 0 {
-		logrus.Tracef("TTL has not expired for key=%v, ttl=%v, requeuing", key, expires)
-		queue.AddAfter(key, expires)
-		return true
-	}
-
-	logrus.Tracef("TTL delete key=%v, modRev=%v", eventKV.key, eventKV.modRevision)
-	if _, _, _, err := l.Delete(ctx, eventKV.key, eventKV.modRevision); err != nil && !errors.Is(err, context.Canceled) {
-		logrus.Errorf("TTL delete trigger failed for key=%v: %v, requeuing", eventKV.key, err)
-		queue.AddAfter(eventKV.key, retryInterval)
-		return true
-	}
-
-	rwMutex.Lock()
-	defer rwMutex.Unlock()
-	delete(store, eventKV.key)
-
-	return true
-}
-
-// ttlEvents starts a goroutine to do a ListWatch on the root prefix. First it lists
-// all non-deleted keys with a page size of 1000, then it starts watching at the
-// revision returned by the initial list. Any keys that have a Lease associated with
-// them are sent into the result channel for deferred handling of TTL expiration.
-func (l *LogStructured) ttlEvents(ctx context.Context) chan *server.Event {
-	result := make(chan *server.Event)
-
-	go func() {
-		defer close(result)
-
-		rev, events, err := l.log.List(ctx, "/", "", 1000, 0, false, false)
-		for len(events) > 0 {
-			if err != nil {
-				logrus.Errorf("TTL event list failed: %v", err)
-				return
-			}
-
-			for _, event := range events {
-				if event.KV.Lease > 0 {
-					result <- event
-				}
-			}
-
-			_, events, err = l.log.List(ctx, "/", events[len(events)-1].KV.Key, 1000, rev, false, false)
-		}
-
-		wr := l.Watch(ctx, "/", rev)
-		if wr.CompactRevision != 0 {
-			logrus.Errorf("TTL event watch failed: %v", server.ErrCompacted)
-			return
-		}
-		for events := range wr.Events {
-			for _, event := range events {
-				if event.KV.Lease > 0 {
-					result <- event
-				}
-			}
-		}
-		logrus.Info("TTL events watch channel closed")
-	}()
-
-	return result
-}
-
-func loadTTLEventKV(rwMutex *sync.RWMutex, store map[string]*ttlEventKV, key string) *ttlEventKV {
-	rwMutex.RLock()
-	defer rwMutex.RUnlock()
-	return store[key]
-}
-
-func storeTTLEventKV(rwMutex *sync.RWMutex, store map[string]*ttlEventKV, eventKV *server.KeyValue) time.Duration {
-	rwMutex.Lock()
-	defer rwMutex.Unlock()
-	expires := time.Duration(eventKV.Lease) * time.Second
-	store[eventKV.Key] = &ttlEventKV{
-		key:         eventKV.Key,
-		modRevision: eventKV.ModRevision,
-		expiredAt:   time.Now().Add(expires),
-	}
-	return expires
 }
 
 func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64) server.WatchResult {

--- a/pkg/testserver/test_server.go
+++ b/pkg/testserver/test_server.go
@@ -101,6 +101,8 @@ func setDatabasePath(endpoint, dir string) (string, error) {
 	hash := fmt.Sprintf("%.8x", sha256.Sum256([]byte(dir)))
 	scheme, _, _ := strings.Cut(endpoint, "://")
 	switch scheme {
+	case "memory":
+		return endpoint, nil
 	case "", "sqlite":
 		// empty scheme means default sqlite db
 		return fmt.Sprintf("sqlite://%s/state.db?_journal=WAL&cache=shared&_busy_timeout=30000&_txlock=immediate", dir), nil

--- a/pkg/ttl/ttl.go
+++ b/pkg/ttl/ttl.go
@@ -1,0 +1,175 @@
+// Package ttl runs lease-driven key expiration on top of any server.Backend.
+//
+// A single goroutine seeds a delaying workqueue from an initial paginated
+// List of leased keys, then watches for new lease events from the next
+// revision onward. A handler goroutine consumes the queue and deletes each
+// key once its lease elapses. Both pkg/drivers/memory and pkg/logstructured
+// share this implementation; the only contract is the List/Watch/Delete
+// subset of server.Backend.
+package ttl
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/k3s-io/kine/pkg/server"
+)
+
+const (
+	// retryInterval is how long we wait before requeueing a key whose Delete
+	// failed for a transient reason.
+	retryInterval = 250 * time.Millisecond
+	// listPageSize is the page size used when seeding the workqueue from the
+	// initial list of leased keys. Backends that ignore the limit parameter
+	// (e.g. the in-memory backend) will return everything in one call; the
+	// pagination loop terminates correctly either way.
+	listPageSize = 1000
+)
+
+type entry struct {
+	key         string
+	modRevision int64
+	expiredAt   time.Time
+}
+
+// Run consumes leased keys from b and deletes each one when its TTL elapses.
+// It blocks until ctx is canceled or the watch channel closes. Callers
+// typically launch this with `go ttl.Run(ctx, backend)`.
+func Run(ctx context.Context, b server.Backend) {
+	queue := workqueue.NewTypedDelayingQueue[string]()
+	var mu sync.RWMutex
+	store := make(map[string]*entry)
+
+	go func() {
+		for handle(ctx, b, &mu, queue, store) {
+		}
+	}()
+
+	rev, err := seed(ctx, b, &mu, queue, store)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			logrus.Errorf("TTL initial list failed: %v", err)
+		}
+		queue.ShutDown()
+		return
+	}
+
+	// Watch from rev+1: seed already covered everything up to rev, so we
+	// only need events strictly after.
+	wr := b.Watch(ctx, "/", rev+1)
+	if wr.CompactRevision != 0 {
+		logrus.Errorf("TTL event watch failed: %v", server.ErrCompacted)
+		queue.ShutDown()
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			queue.ShutDown()
+			return
+		case events, ok := <-wr.Events:
+			if !ok {
+				queue.ShutDown()
+				return
+			}
+			for _, event := range events {
+				if event.Delete || event.KV == nil || event.KV.Lease <= 0 {
+					continue
+				}
+				kv := event.KV
+				stored := load(&mu, store, kv.Key)
+				if stored == nil || kv.ModRevision > stored.modRevision {
+					expires := save(&mu, store, kv)
+					logrus.Tracef("TTL set key=%v modRev=%v ttl=%v", kv.Key, kv.ModRevision, expires)
+					queue.AddAfter(kv.Key, expires)
+				}
+			}
+		}
+	}
+}
+
+// seed pages through every leased key at the current revision and adds it
+// to the workqueue. Pagination is anchored at the revision returned by the
+// first List so subsequent pages are stable.
+func seed(ctx context.Context, b server.Backend, mu *sync.RWMutex, queue workqueue.TypedDelayingInterface[string], store map[string]*entry) (int64, error) {
+	rev, kvs, err := b.List(ctx, "/", "", listPageSize, 0, false)
+	if err != nil {
+		return rev, err
+	}
+	for len(kvs) > 0 {
+		for _, kv := range kvs {
+			if kv.Lease > 0 {
+				expires := save(mu, store, kv)
+				logrus.Tracef("TTL seed key=%v modRev=%v ttl=%v", kv.Key, kv.ModRevision, expires)
+				queue.AddAfter(kv.Key, expires)
+			}
+		}
+		if int64(len(kvs)) < listPageSize {
+			break
+		}
+		_, kvs, err = b.List(ctx, "/", kvs[len(kvs)-1].Key, listPageSize, rev, false)
+		if err != nil {
+			return rev, err
+		}
+	}
+	return rev, nil
+}
+
+// handle processes one queue item. Returns false when the queue has shut
+// down, true otherwise so the caller can keep looping.
+func handle(ctx context.Context, b server.Backend, mu *sync.RWMutex, queue workqueue.TypedDelayingInterface[string], store map[string]*entry) bool {
+	key, shutdown := queue.Get()
+	if shutdown {
+		logrus.Info("TTL events work queue has shut down")
+		return false
+	}
+	defer queue.Done(key)
+
+	e := load(mu, store, key)
+	if e == nil {
+		logrus.Errorf("TTL event not found for key=%v", key)
+		return true
+	}
+
+	if expires := time.Until(e.expiredAt); expires > 0 {
+		logrus.Tracef("TTL has not expired for key=%v, ttl=%v, requeuing", key, expires)
+		queue.AddAfter(key, expires)
+		return true
+	}
+
+	logrus.Tracef("TTL delete key=%v modRev=%v", e.key, e.modRevision)
+	if _, _, _, err := b.Delete(ctx, e.key, e.modRevision); err != nil && !errors.Is(err, context.Canceled) {
+		logrus.Errorf("TTL delete trigger failed for key=%v: %v, requeuing", e.key, err)
+		queue.AddAfter(e.key, retryInterval)
+		return true
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	delete(store, e.key)
+	return true
+}
+
+func load(mu *sync.RWMutex, store map[string]*entry, key string) *entry {
+	mu.RLock()
+	defer mu.RUnlock()
+	return store[key]
+}
+
+func save(mu *sync.RWMutex, store map[string]*entry, kv *server.KeyValue) time.Duration {
+	mu.Lock()
+	defer mu.Unlock()
+	expires := time.Duration(kv.Lease) * time.Second
+	store[kv.Key] = &entry{
+		key:         kv.Key,
+		modRevision: kv.ModRevision,
+		expiredAt:   time.Now().Add(expires),
+	}
+	return expires
+}

--- a/scripts/test-run-memory
+++ b/scripts/test-run-memory
@@ -1,0 +1,10 @@
+#!/bin/bash
+start-test() {
+    KINE_IMAGE=$IMAGE KINE_ENDPOINT="memory://" run-apiserver-tests
+    KINE_IMAGE=$IMAGE KINE_ENDPOINT="memory://" provision-kine
+    local kine_url=$(cat $TEST_DIR/kine/*/metadata/url)
+    K3S_DATASTORE_ENDPOINT=$kine_url provision-cluster
+}
+export -f start-test
+
+LABEL=memory run-test


### PR DESCRIPTION
Hi @brandond long time no see 👋 ... something lived rent free in my mind for the last 7yrs which was an in-memory driver for kine for ephemeral work like e2e tests and ci runs etc. You could kind of do this with sqlite and nats through configuration, but you were just making a translation layer and extra services on top of the memory when you could use a btree and just take it. Full disclosure this was opus 4.6 that wrote this and it passes all tests and I proof read the code and looked like what I would have done so I decided to ship it. Let me know if you want me to make any changes as the AI could have missed something.

Below is the PR description that claude wrote.

## Summary

Adds a pure Go in-memory backend for kine, registered as the `memory://` scheme. State lives entirely in process memory and is lost on shutdown. Intended for ephemeral and test scenarios where the SQL or NATS layers underneath the existing backends are unwanted overhead.

A side effect of building this driver was extracting the lease/TTL machinery out of `pkg/logstructured` into a new `pkg/ttl` package so both backends share one implementation.

## Why this vs. nats memory or sqlite `:memory:`

Both alternatives can keep data in RAM, but they still pay the cost of the layers underneath kine. This driver skips them entirely.

- **vs. nats memory store**: NATS still runs an embedded JetStream server with its own goroutines, KV bucket, JSON encode/decode per entry, and the kine NATS backend layers a btree watcher on top for replay. Even with non-persistent storage you're paying the protocol stack.
- **vs. sqlite `:memory:`**: every operation goes through the SQL parser/planner, the cgo bridge into sqlite3, and kine's `LogStructured` + `SQLLog` path on top of that (poll loop, gap-fill, broadcaster, transaction serialization). `:memory:` only removes the disk; the SQL machinery still runs on every read and write.

This driver is direct in-process state: a slice for the revision log, a btree for key to history, an atomic for the revision counter, a chan-close for watch notification. No SQL, no cgo, no IPC, no encoding.

What that buys you in practice:

- **Faster startup/teardown.** No schema setup, no embedded server, no socket; tests reset by allocating a new `Memory`.
- **No filesystem or port state.** Nothing to clean up between runs, no port allocation conflicts when running tests in parallel.
- **Determinism.** No WAL checkpoints, no async flushes, no compaction lag. Operations land in order and reads see exactly what was written.
- **Smaller surface for test flakes.** Fewer moving parts means fewer things to blame when a test is slow or racy.

Tradeoff: state is process-local and lost on exit. That's the point. This is for tests, ephemeral clusters, and dev loops, not production.

## How the storage is laid out

The driver keeps two structures in sync, and they answer different questions:

- A flat **revision log** (`[]*entry`), one slot per write, ordered by monotonic `currentRevision` (`atomic.Int64`). Source of truth for "what happened, in order." `Watch` replays
it; historical reads at a revision walk it. Each `entry` carries a `prev *entry` pointer to its predecessor for the same key, so previous-KV lookups during watch fanout are O(1)
without re-indexing.
- A **btree** keyed by string (`tidwall/btree.Map[string, []*entry]`) where each value is the full history of that key. Answers "what's at key X" and "what's under prefix P, in
sorted order."

A btree (not a hash map) because the apiserver leans on **ordered range queries**: `List` over a prefix has to return keys in sorted order, and pagination uses a start key to resume mid-range. A hash map gives O(1) point lookup but no order; sorting on every list would be O(n log n) per call. A btree gives both: O(log n) point lookup *and* an ordered iterator you can seek into.

The library is `tidwall/btree`, an in-memory copy-on-write B-tree. Each node holds many keys, which keeps the tree shallow and cache-friendly, comparable to what databases use on disk but tuned for RAM. For this driver:

- **Point lookup** (`Get`, `latest`, `atRevision`): `keys.Get(key)` returns the history slice; we take the last entry, or scan the slice for the largest revision <= a target.
- **Prefix / range scan** (`List`, `Count`): `keys.Iter()` plus `iter.Seek(startKey)` jumps to the first key >= start, then `iter.Next()` walks in sorted order, stopping at the
prefix boundary. Cost is O(log n) to seek plus O(k) for k matching keys, with no scan of unrelated keys.
- **Append on write** (`Create`/`Update`/`Delete`): look up the existing history, append a new `entry`, `keys.Set(key, history)` writes it back, O(log n).

Each value being a *slice of entries* is what makes historical reads cheap: `atRevision(key, rev)` walks just that key's slice (typically short) to find the latest entry at or before `rev`, never touching unrelated keys or the global log.

`Compact` advances `compactRevision`, drops compacted entries from each key's history slice, and trims the flat log; the log stays dense, so the index of the first entry strictly after a revision is just `rev - compactRevision` (clamped). Reads below the boundary return `ErrCompacted`.

## Shared TTL package

`pkg/logstructured/logstructured.go` had an inline lease-expiration implementation: a delaying workqueue seeded from a list, then watching for new lease events and deleting each key when its TTL elapses. The memory driver needs the same behavior, and the only contract is the `List` / `Watch` / `Delete` subset of `server.Backend`, so this PR pulls that machinery into `pkg/ttl` and has both backends call `go ttl.Run(ctx, backend)` from `Start`.

Behavior is unchanged for `LogStructured`; the function signatures and trace logging match what was there before.

## Startup state

`Start` seeds the same two entries the SQL and NATS backends produce on startup so that the apiserver and the rest of kine see a consistent contract:

- `compact_rev_key`: the apiserver-visible compaction marker, normally written by `SQLLog.compactStart`.
- `/registry/health`: the liveness key, normally written by `LogStructured.Start`.

Without these, the apiserver rejects the first read with `illegal resource version from storage: 0`, and starting revision lands at 2, which is what the existing `watcher_test.go` patch in `scripts/test-helpers` already expects (`NewTooLargeResourceVersionError(uint64(102), 2, 0)`).

## What's in it

- **`pkg/drivers/memory/memory.go`**: the driver. Implements `server.Backend` directly (it does not go through `LogStructured`).
  - Append-only revision log with key-history btree as described above; `currentRevision` is an `atomic.Int64`.
  - `Get` / `List` / `Count` / `Watch` / `Compact` / `Create` / `Update` / `Delete` matching the contract the apiserver expects, including historical reads at a revision and
`ErrCompacted` / `ErrFutureRev` semantics.
  - `Watch` uses a chan-close broadcast notified on every append; watchers replay the log from their last-seen revision and filter by prefix. `entry.prev` provides O(1) previous-KV
  access for events.
  - Lease/TTL handled by the shared `pkg/ttl` package.
- **`pkg/drivers/memory/memory_test.go`**: package-level unit tests covering create/get/update/delete, list/range/prefix iteration, historical reads, watches (initial backlog, new events, prev-KV), compaction, and TTL expiration end-to-end.
- **`pkg/ttl/ttl.go`**: new shared package. `Run(ctx, backend)` consumes leased keys and deletes each one when its TTL elapses. Pagination loop terminates correctly whether or not the backend honors `limit` (the in-memory backend ignores it).
- **`pkg/logstructured/logstructured.go`**: deletes the inline TTL implementation and calls `ttl.Run` instead. No behavior change for SQL backends.
- **`pkg/endpoint/init.go`**: registers the driver via blank import so `memory://` resolves at runtime.
- **`pkg/testserver/test_server.go`**: recognizes the `memory` scheme in `setDatabasePath` (no DSN rewrite needed; pass through unchanged) so the upstream etcd3 apiserver test
harness can target it.
- **`scripts/test-run-memory`**: runner that invokes the upstream etcd3 storage tests against `memory://` and then provisions a k3s cluster pointed at a kine container using the in-memory backend, mirroring the existing `test-run-sqlite` / `test-run-nats` runners.

## Test plan

- [x] `go test ./pkg/drivers/memory/...`
- [x] `go test ./pkg/logstructured/...` (TTL extraction is non-breaking)
- [x] `source ./scripts/test-helpers && build-apiserver-tests`
- [x] `KINE_ENDPOINT=memory:// ./bin/etcd3.test -test.failfast -test.count 1 -test.parallel 1 -test.timeout 15m`, all 78 tests pass
- [ ] `scripts/test-run-memory` end-to-end (kine container + k3s cluster)