### PR TITLE
Disable use-waitgroup-go check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
         - {name: max-public-structs, disabled: true}
         - {name: unused-parameter, disabled: true}
         - {name: unused-receiver, disabled: true}
+        - {name: use-waitgroup-go, disabled: true}
         - {name: var-naming, disabled: true}
   exclusions:
     generated: lax


### PR DESCRIPTION
We are fine with still calling Add/Done by hand, where it makes sense.

Fixes:
```
pkg/drivers/nats/new.go:96:3: use-waitgroup-go: replace wg.Add()...go {...wg.Done()...} with wg.Go(...) (revive)
		wg.Add(1)
		^
pkg/endpoint/endpoint.go:143:2: use-waitgroup-go: replace wg.Add()...go {...wg.Done()...} with wg.Go(...) (revive)
	wg.Add(1)
	^
2 issues:
* revive: 2
```