### PR TITLE
Fix nits in memory driver

### DIFF
--- a/pkg/drivers/memory/memory.go
+++ b/pkg/drivers/memory/memory.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -65,31 +66,14 @@ type Memory struct {
 var _ server.Backend = &Memory{}
 
 func (m *Memory) Start(ctx context.Context) error {
-	// Seed the same startup entries that SQL-backed and NATS backends do:
-	//   1. compact_rev_key — written by SQLLog.compactStart; gives the backend
-	//      a non-zero starting revision (apiserver rejects rev=0).
-	//   2. /registry/health — written by LogStructured.Start; the apiserver
-	//      uses it as a liveness probe.
-	m.mu.Lock()
-	rev := m.nextRevision()
-	m.appendEntry(&entry{
-		revision:       rev,
-		key:            "compact_rev_key",
-		createRevision: rev,
-		version:        1,
-		created:        true,
-	})
-	rev = m.nextRevision()
-	m.appendEntry(&entry{
-		revision:       rev,
-		key:            "/registry/health",
-		value:          []byte(`{"health":"true"}`),
-		createRevision: rev,
-		version:        1,
-		created:        true,
-	})
-	m.mu.Unlock()
-
+	// See https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L970
+	if _, err := m.Create(ctx, server.HealthKey, []byte(server.HealthVal), 0); err != nil {
+		logrus.Errorf("Failed to create health check key: %v", err)
+	}
+	// update health to create rev=2 for consistency with other backends
+	if _, _, _, err := m.Update(ctx, server.HealthKey, []byte(server.HealthVal), 1, 0); err != nil {
+		logrus.Errorf("Failed to update health check key: %v", err)
+	}
 	go ttl.Run(ctx, m)
 	return nil
 }
@@ -127,6 +111,7 @@ func (m *Memory) appendEntry(e *entry) {
 		e.prev = hist[len(hist)-1]
 	}
 	m.keys.Set(e.key, append(hist, e))
+	m.broadcast()
 }
 
 // broadcast wakes every goroutine currently blocked on getNotifyCh.
@@ -237,7 +222,6 @@ func (m *Memory) Create(ctx context.Context, key string, value []byte, lease int
 		lease:          lease,
 		created:        true,
 	})
-	m.broadcast()
 	return rev, nil
 }
 
@@ -264,7 +248,6 @@ func (m *Memory) Update(ctx context.Context, key string, value []byte, revision,
 		lease:          lease,
 	}
 	m.appendEntry(e)
-	m.broadcast()
 	return rev, e.toKeyValue(), true, nil
 }
 
@@ -291,7 +274,6 @@ func (m *Memory) Delete(ctx context.Context, key string, revision int64) (int64,
 		lease:          latest.lease,
 		deleted:        true,
 	})
-	m.broadcast()
 	return rev, latest.toKeyValue(), true, nil
 }
 
@@ -452,10 +434,10 @@ func (m *Memory) Compact(ctx context.Context, revision int64) (int64, error) {
 
 	rev := m.currentRevision.Load()
 	if revision > rev {
-		return rev, nil
+		return 0, server.ErrFutureRev
 	}
 	if revision <= m.compactRevision {
-		return rev, nil
+		return 0, server.ErrCompacted
 	}
 
 	var toRemove []string
@@ -499,16 +481,14 @@ func (m *Memory) Compact(ctx context.Context, revision int64) (int64, error) {
 	}
 
 	// Trim the log. Because the log is dense and ordered by revision, the cut
-	// point is just (revision - oldCompactRevision); everything before it has
-	// revision <= the target and is no longer reachable via Watch.
-	cut := int(revision - m.compactRevision)
-	if cut > len(m.log) {
-		cut = len(m.log)
+	// point is just before (revision - oldCompactRevision); everything before that has
+	// revision < the target and is no longer reachable via Watch.
+	// We know that revision must be > currentRevision and <= compactRevision,
+	// but guard against cutting out of bounds or removing all entries.
+	if cut := int(revision-m.compactRevision) - 1; cut > 0 {
+		// use slices.Delete to bulk-zero deleted elements from the backing array for GC
+		m.log = slices.Delete(m.log, 0, cut)
 	}
-	for i := 0; i < cut; i++ {
-		m.log[i] = nil
-	}
-	m.log = m.log[cut:]
 
 	m.compactRevision = revision
 	return rev, nil

--- a/pkg/drivers/memory/memory_test.go
+++ b/pkg/drivers/memory/memory_test.go
@@ -444,10 +444,10 @@ func TestCompactTrimsHistory(t *testing.T) {
 	}
 
 	// After compact at rev 4 every log entry is at-or-below the boundary, so
-	// the log is fully trimmed. Per-key history in m.keys still holds each
+	// the log should contain only 4. Per-key history in m.keys still holds each
 	// key's floor entry so reads at the compact boundary resolve correctly.
-	if got := len(b.log); got != 0 {
-		t.Fatalf("log length after compact: got %d, want 0", got)
+	if got := len(b.log); got != 1 {
+		t.Fatalf("log length after compact: got %d, want 1", got)
 	}
 	histA, _ := b.keys.Get("/test/a")
 	if got := len(histA); got != 1 {
@@ -463,12 +463,12 @@ func TestCompactTrimsHistory(t *testing.T) {
 	noErr(t, err)
 	expEqual(t, "v3", string(kv.Value))
 
-	// Calling Compact at a rev <= current compactRevision is a no-op.
-	if _, err := b.Compact(ctx, 2); err != nil {
-		t.Fatal(err)
+	// Calling Compact at a rev <= current compactRevision is an error
+	if _, err := b.Compact(ctx, 2); err == nil {
+		t.Fatal("expected error, got nil")
 	}
-	if got := len(b.log); got != 0 {
-		t.Fatalf("log length after no-op compact: got %d, want 0", got)
+	if got := len(b.log); got != 1 {
+		t.Fatalf("log length after no-op compact: got %d, want 1", got)
 	}
 }
 
@@ -494,9 +494,9 @@ func TestCompactDropsTombstones(t *testing.T) {
 	if !ok || len(histB) != 1 {
 		t.Fatalf("/test/b history after compact: got %v, want 1 entry", histB)
 	}
-	// Every log entry was at-or-below the boundary, so the log is fully trimmed.
-	if got := len(b.log); got != 0 {
-		t.Fatalf("log length after compact: got %d, want 0", got)
+	// Every log entry was at-or-below the boundary, so the log contains only last entry
+	if got := len(b.log); got != 1 {
+		t.Fatalf("log length after compact: got %d, want 1", got)
 	}
 }
 
@@ -517,15 +517,18 @@ func TestCompactStraddlesBoundary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Log keeps entries strictly above compactRev: rev 4 and rev 5.
-	if got := len(b.log); got != 2 {
-		t.Fatalf("log length after compact(3): got %d, want 2", got)
+	// Log keeps entries at or above compactRev: rev 3, 4, 5.
+	if got := len(b.log); got != 3 {
+		t.Fatalf("log length after compact(3): got %d, want 3", got)
 	}
-	if got := b.log[0].revision; got != 4 {
-		t.Fatalf("log[0].revision: got %d, want 4", got)
+	if got := b.log[0].revision; got != 3 {
+		t.Fatalf("log[0].revision: got %d, want 3", got)
 	}
-	if got := b.log[1].revision; got != 5 {
-		t.Fatalf("log[1].revision: got %d, want 5", got)
+	if got := b.log[1].revision; got != 4 {
+		t.Fatalf("log[1].revision: got %d, want 4", got)
+	}
+	if got := b.log[2].revision; got != 5 {
+		t.Fatalf("log[2].revision: got %d, want 5", got)
 	}
 
 	// logIndexAfter math is anchored at compactRev+1 = 4.

--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -112,14 +112,14 @@ func (b *Backend) Start(ctx context.Context) error {
 
 	b.l.Infof("Creating health key...")
 
-	rev, err := b.Create(ctx, "/registry/health", nil, 0)
+	rev, err := b.Create(ctx, server.HealthKey, []byte(server.HealthVal), 0)
 	if err != nil && err != server.ErrKeyExists {
 		b.l.Errorf("failed to create health key: %v", err)
 		return err
 	}
 
-	// Perform an update to increment the revision.
-	_, _, _, err = b.Update(ctx, "/registry/health", []byte(`{"health":"true"}`), rev, 0)
+	// update health to create rev=2 for consistency with other backends
+	_, _, _, err = b.Update(ctx, server.HealthKey, []byte(server.HealthVal), rev, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -40,10 +40,8 @@ func (l *LogStructured) Start(ctx context.Context) error {
 		return err
 	}
 	// See https://github.com/kubernetes/kubernetes/blob/442a69c3bdf6fe8e525b05887e57d89db1e2f3a5/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go#L97
-	if _, err := l.Create(ctx, "/registry/health", []byte(`{"health":"true"}`), 0); err != nil {
-		if err != server.ErrKeyExists {
-			logrus.Errorf("Failed to create health check key: %v", err)
-		}
+	if _, err := l.Create(ctx, server.HealthKey, []byte(server.HealthVal), 0); err != nil && err != server.ErrKeyExists {
+		logrus.Errorf("Failed to create health check key: %v", err)
 	}
 	go ttl.Run(ctx, l)
 	return nil

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -705,12 +705,20 @@ func (s *SQLLog) DbSize(ctx context.Context) (int64, error) {
 }
 
 func (s *SQLLog) Compact(ctx context.Context, targetCompactRev int64) (int64, error) {
-	if s.compactInterval <= 0 {
-		// manual compact is a no-op unless automatic compaction is disabled
-		compactRev, _ := s.d.GetCompactRevision(s.ctx)
-		s.compactIter(compactRev, targetCompactRev)
+	currentRev, _ := s.CurrentRevision(ctx)
+	if targetCompactRev > currentRev {
+		return 0, server.ErrFutureRev
 	}
-	return s.CurrentRevision(ctx)
+	compactRev, _ := s.d.GetCompactRevision(s.ctx)
+	if targetCompactRev <= compactRev {
+		return 0, server.ErrCompacted
+	}
+	// manual compact is a no-op unless automatic compaction is disabled
+	if s.compactInterval <= 0 {
+		s.compactIter(compactRev, targetCompactRev)
+		return s.CurrentRevision(ctx)
+	}
+	return currentRev, nil
 }
 
 func (s *SQLLog) WaitForSyncTo(revision int64) {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -19,6 +19,11 @@ var (
 	ErrGRPCUnhealthy = rpctypes.ErrGRPCUnhealthy
 )
 
+const (
+	HealthKey = `/registry/health`
+	HealthVal = `{"health":"true"}`
+)
+
 type Backend interface {
 	Start(ctx context.Context) error
 	Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *KeyValue, error)


### PR DESCRIPTION
1. We don't need compact_rev_key, thats only used for SQL; the memory driver has `m.compactRevision`
2. Move `broadcast()` into `appendEntry()` since its always called after it
3. Simplify log trimming in Compact, and ensure that compact always leaves one revision in the log for consistency with etcd and sql-based backends.
4. Move a couple strings into constants, since they are common to all drivers
5. Don't allow compacting future or already-compacted revisions, for consistency with etcd