### PR TITLE
T4 multi-node issues fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/shengdoushi/base58 v1.0.0
 	github.com/sirupsen/logrus v1.9.4
-	github.com/t4db/t4 v1.0.2
+	github.com/t4db/t4 v1.0.3
 	github.com/tidwall/btree v1.8.1
 	github.com/urfave/cli/v2 v2.27.7
 	go.etcd.io/etcd/api/v3 v3.6.11

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/t4db/t4 v1.0.2 h1:/YhMDt43AWZAsvShszj/waawi2xCg2LvQ8r0ljlkVlo=
-github.com/t4db/t4 v1.0.2/go.mod h1:j/5by/iUcGJlPUXIbT5zOrEuB0k+XQ4Xg2dHU75+loc=
+github.com/t4db/t4 v1.0.3 h1:2flb5uixIP4uN6TdTRaX00Eoc4jnmdzXPlGcQLN7Rrc=
+github.com/t4db/t4 v1.0.3/go.mod h1:j/5by/iUcGJlPUXIbT5zOrEuB0k+XQ4Xg2dHU75+loc=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=

--- a/pkg/drivers/t4/backend.go
+++ b/pkg/drivers/t4/backend.go
@@ -34,17 +34,15 @@ func (b *backend) Start(ctx context.Context) error {
 	)
 	deadline := time.Now().Add(retryTimeout)
 	for {
-		rev, err := b.node.Create(ctx, kserver.HealthKey, []byte(kserver.HealthVal), 0)
-		if err == nil {
-			if _, _, _, uerr := b.node.Update(ctx, kserver.HealthKey, []byte(kserver.HealthVal), rev, 0); uerr != nil {
-				logrus.Errorf("t4: failed to update health check key: %v", uerr)
+		_, err := b.node.Create(ctx, kserver.HealthKey, []byte(kserver.HealthVal), 0)
+		if err == nil || errors.Is(err, t4.ErrKeyExists) {
+			if err = b.refreshHealthKey(ctx); err == nil {
+				go ttl.Run(ctx, b)
+				return nil
 			}
-			go ttl.Run(ctx, b)
-			return nil
 		}
-		if errors.Is(err, t4.ErrKeyExists) {
-			go ttl.Run(ctx, b)
-			return nil
+		if errors.Is(err, t4.ErrClosed) {
+			return err
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("t4: backend not ready after %s: %w", retryTimeout, err)
@@ -56,6 +54,18 @@ func (b *backend) Start(ctx context.Context) error {
 		case <-time.After(retryInterval):
 		}
 	}
+}
+
+func (b *backend) refreshHealthKey(ctx context.Context) error {
+	kv, err := b.node.LinearizableGet(ctx, kserver.HealthKey)
+	if err != nil {
+		return err
+	}
+	if kv == nil {
+		return errors.New("health key disappeared")
+	}
+	_, _, _, err = b.node.Update(ctx, kserver.HealthKey, []byte(kserver.HealthVal), kv.Revision, 0)
+	return err
 }
 
 func (b *backend) CurrentRevision(_ context.Context) (int64, error) {
@@ -73,7 +83,7 @@ func (b *backend) Get(ctx context.Context, key, _ string, _, revision int64, key
 
 	kv, err := b.node.LinearizableGet(ctx, key, readOpts(revision)...)
 	if err != nil {
-		return curRev, nil, translateReadErr(err)
+		return curRev, nil, translateErr(err)
 	}
 	return curRev, toServerKV(kv, keysOnly), nil
 }
@@ -87,12 +97,14 @@ func readOpts(revision int64) []t4.ReadOption {
 	return []t4.ReadOption{t4.WithRevision(revision)}
 }
 
-// translateReadErr maps t4-internal compaction/future-rev errors to the
-// kine sentinel errors that apiserver tests check for.
-func translateReadErr(err error) error {
+// translateErr maps t4-internal errors to the kine/etcd sentinel errors that
+// apiserver understands and retries appropriately.
+func translateErr(err error) error {
 	switch {
 	case err == nil:
 		return nil
+	case errors.Is(err, t4.ErrNoLeader):
+		return kserver.ErrNoLeader
 	case errors.Is(err, t4.ErrCompacted):
 		return kserver.ErrCompacted
 	case errors.Is(err, t4.ErrFutureRevision):
@@ -107,13 +119,13 @@ func (b *backend) Create(ctx context.Context, key string, value []byte, lease in
 	if errors.Is(err, t4.ErrKeyExists) {
 		return 0, kserver.ErrKeyExists
 	}
-	return rev, err
+	return rev, translateErr(err)
 }
 
 func (b *backend) Delete(ctx context.Context, key string, revision int64) (int64, *kserver.KeyValue, bool, error) {
 	newRev, oldKV, deleted, err := b.node.DeleteIfRevision(ctx, key, revision)
 	if err != nil {
-		return 0, nil, false, err
+		return 0, nil, false, translateErr(err)
 	}
 	return newRev, toServerKV(oldKV, false), deleted, nil
 }
@@ -135,7 +147,7 @@ func (b *backend) List(ctx context.Context, prefix, startKey string, limit, revi
 	}
 	kvs, err := b.node.LinearizableList(ctx, prefix, opts...)
 	if err != nil {
-		return curRev, nil, translateReadErr(err)
+		return curRev, nil, translateErr(err)
 	}
 	out := make([]*kserver.KeyValue, 0, len(kvs))
 	for _, kv := range kvs {
@@ -158,7 +170,7 @@ func (b *backend) Count(ctx context.Context, prefix, startKey string, revision i
 	}
 	count, err := b.node.LinearizableCount(ctx, prefix, opts...)
 	if err != nil {
-		return curRev, 0, translateReadErr(err)
+		return curRev, 0, translateErr(err)
 	}
 	return curRev, count, nil
 }
@@ -166,7 +178,7 @@ func (b *backend) Count(ctx context.Context, prefix, startKey string, revision i
 func (b *backend) Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *kserver.KeyValue, bool, error) {
 	newRev, oldKV, updated, err := b.node.Update(ctx, key, value, revision, lease)
 	if err != nil {
-		return 0, nil, false, err
+		return 0, nil, false, translateErr(err)
 	}
 	return newRev, toServerKV(oldKV, false), updated, nil
 }
@@ -193,11 +205,7 @@ func (b *backend) Watch(ctx context.Context, key string, revision int64) kserver
 		// and apiserver's watchCache rejects them as duplicate/out-of-order.
 		ch, err := b.node.Watch(ctx, key, revision, t4.WithPrevKV())
 		if err != nil {
-			if errors.Is(err, t4.ErrCompacted) {
-				errCh <- kserver.ErrCompacted
-			} else {
-				errCh <- fmt.Errorf("t4 watch: %w", err)
-			}
+			errCh <- translateErr(err)
 			return
 		}
 		// Coalesce events that are already buffered into a single slice send.
@@ -246,7 +254,7 @@ func (b *backend) DbSize(_ context.Context) (int64, error) {
 
 func (b *backend) Compact(ctx context.Context, revision int64) (int64, error) {
 	if err := b.node.Compact(ctx, revision); err != nil {
-		return 0, err
+		return 0, translateErr(err)
 	}
 	return revision, nil
 }

--- a/pkg/drivers/t4/backend_smoke_test.go
+++ b/pkg/drivers/t4/backend_smoke_test.go
@@ -91,6 +91,41 @@ func TestT4Backend_CreateGetUpdateDelete(t *testing.T) {
 	}
 }
 
+func TestT4Backend_StartRefreshesExistingHealthKey(t *testing.T) {
+	dir := t.TempDir()
+
+	start := func(t *testing.T) (*backend, context.CancelFunc, *sync.WaitGroup) {
+		t.Helper()
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := &sync.WaitGroup{}
+		_, b, err := New(ctx, wg, &drivers.Config{DataSourceName: dir})
+		if err != nil {
+			cancel()
+			t.Fatalf("t4 New: %v", err)
+		}
+		tb := b.(*backend)
+		if err := tb.Start(ctx); err != nil {
+			cancel()
+			t.Fatalf("t4 Start: %v", err)
+		}
+		return tb, cancel, wg
+	}
+
+	first, cancelFirst, wgFirst := start(t)
+	firstRev := first.node.CurrentRevision()
+	cancelFirst()
+	wgFirst.Wait()
+
+	second, cancelSecond, wgSecond := start(t)
+	defer func() {
+		cancelSecond()
+		wgSecond.Wait()
+	}()
+	if secondRev := second.node.CurrentRevision(); secondRev <= firstRev {
+		t.Fatalf("restart current revision = %d, want > %d", secondRev, firstRev)
+	}
+}
+
 func TestT4Backend_ListAndCount(t *testing.T) {
 	b, ctx := newLocalBackend(t)
 

--- a/pkg/drivers/t4/backend_smoke_test.go
+++ b/pkg/drivers/t4/backend_smoke_test.go
@@ -103,7 +103,11 @@ func TestT4Backend_StartRefreshesExistingHealthKey(t *testing.T) {
 			cancel()
 			t.Fatalf("t4 New: %v", err)
 		}
-		tb := b.(*backend)
+		tb, ok := b.(*backend)
+		if !ok {
+			cancel()
+			t.Fatalf("backend type = %T, want *backend", b)
+		}
 		if err := tb.Start(ctx); err != nil {
 			cancel()
 			t.Fatalf("t4 Start: %v", err)

--- a/pkg/drivers/t4/t4.go
+++ b/pkg/drivers/t4/t4.go
@@ -159,6 +159,9 @@ func parseConfig(ctx context.Context, cfg *drivers.Config) (*t4.Config, error) {
 	}
 
 	if cfg.S3Config.Bucket != "" {
+		if err := validateS3Config(cfg.S3Config); err != nil {
+			return nil, err
+		}
 		store, err := t4obj.NewS3StoreFromConfig(ctx, t4obj.S3Config{
 			Bucket:          cfg.S3Config.Bucket,
 			Prefix:          cfg.S3Config.Folder,
@@ -259,6 +262,19 @@ func parseConfig(ctx context.Context, cfg *drivers.Config) (*t4.Config, error) {
 	nodeCfg.PeerClientTLS = client
 
 	return nodeCfg, nil
+}
+
+func validateS3Config(cfg drivers.S3Config) error {
+	if (cfg.AccessKey == "") != (cfg.SecretKey == "") {
+		return errors.New("S3 static credentials require both --s3-access-key/AWS_ACCESS_KEY_ID and --s3-secret-key/AWS_SECRET_ACCESS_KEY")
+	}
+	if cfg.SessionToken != "" && cfg.AccessKey == "" {
+		return errors.New("S3 session token requires --s3-access-key/AWS_ACCESS_KEY_ID and --s3-secret-key/AWS_SECRET_ACCESS_KEY")
+	}
+	if cfg.AccessKey == "" && cfg.Profile == "" {
+		return errors.New("S3 credentials not configured; set --s3-access-key/AWS_ACCESS_KEY_ID and --s3-secret-key/AWS_SECRET_ACCESS_KEY, or set --s3-profile/AWS_PROFILE")
+	}
+	return nil
 }
 
 // peerTLSCredentials builds gRPC TransportCredentials for the t4 peer

--- a/pkg/drivers/t4/t4_test.go
+++ b/pkg/drivers/t4/t4_test.go
@@ -26,8 +26,10 @@ func TestParseConfigFailsWithoutCredentialsWhenBucketSet(t *testing.T) {
 	if err == nil {
 		t.Fatal("parseConfig returned nil error")
 	}
-	if !strings.Contains(err.Error(), "credentials") {
-		t.Fatalf("parseConfig error = %q, want mention of credentials", err)
+	for _, want := range []string{"S3 credentials not configured", "--s3-access-key", "AWS_ACCESS_KEY_ID", "--s3-profile", "AWS_PROFILE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("parseConfig error = %q, want mention of %q", err, want)
+		}
 	}
 }
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -17,6 +17,7 @@ var (
 	ErrKeyExists     = rpctypes.ErrGRPCDuplicateKey
 	ErrCompacted     = rpctypes.ErrGRPCCompacted
 	ErrFutureRev     = rpctypes.ErrGRPCFutureRev
+	ErrNoLeader      = rpctypes.ErrGRPCNoLeader
 	ErrGRPCUnhealthy = rpctypes.ErrGRPCUnhealthy
 )
 


### PR DESCRIPTION
Fixes #677 

Fix t4 leader-change and shutdown behavior, and update the Kine t4 driver to surface retryable no-leader errors correctly.

Changes:

- Fixed follower takeover getting stuck after a no-write leader term by teaching followers the leader’s election term from the lock record, not only from WAL traffic. Without writes, followers never advanced their local term and kept losing takeover to the dead leader lock.
- Fixed restarted former followers failing to become leader when the old leader was gone. The same missing-term observation made the restarted follower repeatedly follow a dead leader instead of winning takeover.
- Fixed duplicate node-id replacement leaving the old process alive and serving broken requests by ensuring the superseded node detects the newer lock term and closes cleanly.
- Fixed noisy/raw request failures during leader failover by normalizing unreachable-leader read/write forwarding errors to `t4.ErrNoLeader`, and mapping that to kine’s `kserver.ErrNoLeader` so clients retry a known no-leader condition instead of seeing raw peer dial errors. I haven't decided on enqueuing requests yet, so response with `ErrNoLeader` explicitly for now.
- Fixed a shutdown panic where watch startup could race with store close and touch Pebble after it was closed. Watch registration is now coordinated with store shutdown, and closed stores reject ready waits/watches with ErrClosed.
- Fixed misleading Kine S3 credential errors by validating Kine’s S3 config before calling t4, so users see Kine/AWS flags and env vars instead of t4-specific T4_S3_* names.
- Fixed Kine t4 driver restart behavior when the health key already exists by refreshing the key before declaring the backend started, so startup still advances the health revision consistently.

