### PR TITLE
Don't cache linters

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -16,4 +16,5 @@ jobs:
         with:
           shellcheck: false
           pyflakes: false
+          cache: false
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,7 @@ jobs:
       uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
       with:
         version: v2.7
+        skip-cache: true
 
     - name: Validate
       run: ./scripts/validate


### PR DESCRIPTION
Both `golangci-lint-action` and the `raven-actions/actionlint` use caching by default. However, as these actions are only ever run on PRs, the cache can never get reused and is always invalidated by the next PR. This leads to the cache being filled with useless entries. 

<img width="987" height="759" alt="image" src="https://github.com/user-attachments/assets/3024e9fd-fa2f-4975-8d43-ba27ed91629b" />


Signed-off-by: Derek Nola <derek.nola@suse.com>