### PR TITLE
Fix SQLite name affinity and LIKE optimization

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -38,9 +38,10 @@ var (
 		WHERE (deleted = 0 OR ?)
 		ORDER BY name ASC
 		`
-	CurrentRevSQL = `SELECT MAX(id) AS current_rev FROM kine`
-	CompactRevSQL = `SELECT MAX(prev_revision) AS compact_rev FROM kine WHERE name = 'compact_rev_key'`
-	FiltersRevSQL = `SELECT MAX(id) AS id FROM kine WHERE name LIKE ? ESCAPE '^' %s GROUP BY name`
+	CurrentRevSQL      = `SELECT MAX(id) AS current_rev FROM kine`
+	CompactRevSQL      = `SELECT MAX(prev_revision) AS compact_rev FROM kine WHERE name = 'compact_rev_key'`
+	FiltersRevSQL      = `SELECT MAX(id) AS id FROM kine WHERE name LIKE ? ESCAPE '^' %s GROUP BY name`
+	FiltersRevRangeSQL = `SELECT MAX(id) AS id FROM kine WHERE name >= ? AND name < ? %s GROUP BY name`
 
 	listSQL    = fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, FiltersRevSQL)
 	listValSQL = fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, FiltersRevSQL)
@@ -50,6 +51,7 @@ type ErrRetry func(error) bool
 type TranslateErr func(error) error
 type ErrCode func(error) string
 type SubstituteFunc func(string) string
+type PrefixRangeFunc func(string) (string, string, bool)
 
 type ConnectionPoolConfig struct {
 	MaxIdle     int           // zero means defaultMaxIdleConns; negative means 0
@@ -61,36 +63,46 @@ type ConnectionPoolConfig struct {
 type Generic struct {
 	sync.Mutex
 
-	LockWrites              bool
-	LastInsertID            bool
-	DB                      *sql.DB
-	GetSingleSQL            *query.Named
-	GetSingleValSQL         *query.Named
-	ListCurrentSQL          *query.Named
-	ListCurrentValSQL       *query.Named
-	ListRevisionStartSQL    *query.Named
-	ListRevisionStartValSQL *query.Named
-	GetRevisionAfterSQL     *query.Named
-	GetRevisionAfterValSQL  *query.Named
-	CountCurrentSQL         *query.Named
-	CountRevisionSQL        *query.Named
-	AfterOldValSQL          *query.Named
-	CurrentRevSQL           *query.Named
-	CompactRevSQL           *query.Named
-	DeleteSQL               *query.Named
-	CompactSQL              *query.Named
-	UpdateCompactSQL        *query.Named
-	PostCompactSQL          *query.Named
-	InsertSQL               *query.Named
-	FillSQL                 *query.Named
-	InsertLastInsertIDSQL   *query.Named
-	GetSizeSQL              *query.Named
-	Retry                   ErrRetry
-	InsertRetry             ErrRetry
-	TranslateErr            TranslateErr
-	TranslateStartKeyFunc   SubstituteFunc
-	ErrCode                 ErrCode
-	FillRetryDuration       time.Duration
+	LockWrites                   bool
+	LastInsertID                 bool
+	DB                           *sql.DB
+	GetSingleSQL                 *query.Named
+	GetSingleValSQL              *query.Named
+	ListCurrentSQL               *query.Named
+	ListCurrentValSQL            *query.Named
+	ListRevisionStartSQL         *query.Named
+	ListRevisionStartValSQL      *query.Named
+	GetRevisionAfterSQL          *query.Named
+	GetRevisionAfterValSQL       *query.Named
+	CountCurrentSQL              *query.Named
+	CountRevisionSQL             *query.Named
+	ListCurrentRangeSQL          *query.Named
+	ListCurrentRangeValSQL       *query.Named
+	ListRevisionStartRangeSQL    *query.Named
+	ListRevisionStartRangeValSQL *query.Named
+	GetRevisionAfterRangeSQL     *query.Named
+	GetRevisionAfterRangeValSQL  *query.Named
+	CountCurrentRangeSQL         *query.Named
+	CountRevisionRangeSQL        *query.Named
+	AfterOldValRangeSQL          *query.Named
+	AfterOldValSQL               *query.Named
+	CurrentRevSQL                *query.Named
+	CompactRevSQL                *query.Named
+	DeleteSQL                    *query.Named
+	CompactSQL                   *query.Named
+	UpdateCompactSQL             *query.Named
+	PostCompactSQL               *query.Named
+	InsertSQL                    *query.Named
+	FillSQL                      *query.Named
+	InsertLastInsertIDSQL        *query.Named
+	GetSizeSQL                   *query.Named
+	Retry                        ErrRetry
+	InsertRetry                  ErrRetry
+	TranslateErr                 TranslateErr
+	TranslateStartKeyFunc        SubstituteFunc
+	PrefixRange                  PrefixRangeFunc
+	ErrCode                      ErrCode
+	FillRetryDuration            time.Duration
 }
 
 func (d *Generic) Migrate(ctx context.Context) {
@@ -188,14 +200,20 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 	return &Generic{
 		DB: db,
 
-		ListCurrentSQL:          query.New(fmt.Sprintf(listSQL, "AND name >= ?"), paramCharacter, numbered, "ListCurrent"),
-		ListCurrentValSQL:       query.New(fmt.Sprintf(listValSQL, "AND name >= ?"), paramCharacter, numbered, "ListCurrentVal"),
-		ListRevisionStartSQL:    query.New(fmt.Sprintf(listSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStart"),
-		ListRevisionStartValSQL: query.New(fmt.Sprintf(listValSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStartVal"),
-		GetRevisionAfterSQL:     query.New(fmt.Sprintf(listSQL, "AND name >= ? AND id <= ?"), paramCharacter, numbered, "GetRevisionAfter"),
-		GetRevisionAfterValSQL:  query.New(fmt.Sprintf(listValSQL, "AND name >= ? AND id <= ?"), paramCharacter, numbered, "GetRevisionAfterVal"),
-		CurrentRevSQL:           query.New(CurrentRevSQL, paramCharacter, numbered, "CurrentRev"),
-		CompactRevSQL:           query.New(CompactRevSQL, paramCharacter, numbered, "CompactRev"),
+		ListCurrentSQL:               query.New(fmt.Sprintf(listSQL, "AND name >= ?"), paramCharacter, numbered, "ListCurrent"),
+		ListCurrentValSQL:            query.New(fmt.Sprintf(listValSQL, "AND name >= ?"), paramCharacter, numbered, "ListCurrentVal"),
+		ListRevisionStartSQL:         query.New(fmt.Sprintf(listSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStart"),
+		ListRevisionStartValSQL:      query.New(fmt.Sprintf(listValSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStartVal"),
+		GetRevisionAfterSQL:          query.New(fmt.Sprintf(listSQL, "AND name >= ? AND id <= ?"), paramCharacter, numbered, "GetRevisionAfter"),
+		GetRevisionAfterValSQL:       query.New(fmt.Sprintf(listValSQL, "AND name >= ? AND id <= ?"), paramCharacter, numbered, "GetRevisionAfterVal"),
+		ListCurrentRangeSQL:          query.New(fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND name >= ?")), paramCharacter, numbered, "ListCurrentRange"),
+		ListCurrentRangeValSQL:       query.New(fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND name >= ?")), paramCharacter, numbered, "ListCurrentRangeVal"),
+		ListRevisionStartRangeSQL:    query.New(fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND id <= ?")), paramCharacter, numbered, "ListRevisionStartRange"),
+		ListRevisionStartRangeValSQL: query.New(fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND id <= ?")), paramCharacter, numbered, "ListRevisionStartRangeVal"),
+		GetRevisionAfterRangeSQL:     query.New(fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND name >= ? AND id <= ?")), paramCharacter, numbered, "GetRevisionAfterRange"),
+		GetRevisionAfterRangeValSQL:  query.New(fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND name >= ? AND id <= ?")), paramCharacter, numbered, "GetRevisionAfterRangeVal"),
+		CurrentRevSQL:                query.New(CurrentRevSQL, paramCharacter, numbered, "CurrentRev"),
+		CompactRevSQL:                query.New(CompactRevSQL, paramCharacter, numbered, "CompactRev"),
 
 		GetSingleSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
@@ -225,6 +243,20 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 			WHERE (deleted = 0 OR ?)`,
 			CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevSQL, "AND name >= ? AND id <= ?")), paramCharacter, numbered, "CountRevision"),
 
+		CountCurrentRangeSQL: query.New(fmt.Sprintf(`
+			SELECT (%s), COUNT(id)
+			FROM kine
+			INNER JOIN (%s) AS mkv USING (id)
+			WHERE (deleted = 0 OR ?)`,
+			CurrentRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND name >= ?")), paramCharacter, numbered, "CountCurrentRange"),
+
+		CountRevisionRangeSQL: query.New(fmt.Sprintf(`
+			SELECT (%s), (%s), COUNT(id)
+			FROM kine
+			INNER JOIN (%s) AS mkv USING (id)
+			WHERE (deleted = 0 OR ?)`,
+			CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevRangeSQL, "AND name >= ? AND id <= ?")), paramCharacter, numbered, "CountRevisionRange"),
+
 		AfterOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
 			FROM (%s) AS current, (%s) AS compact, kine
@@ -232,6 +264,15 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 			AND	id > ?
 			ORDER BY id ASC`,
 			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterOldVal"),
+
+		AfterOldValRangeSQL: query.New(fmt.Sprintf(`
+			SELECT current_rev, compact_rev, %s
+			FROM (%s) AS current, (%s) AS compact, kine
+			WHERE	name >= ?
+			AND	name < ?
+			AND	id > ?
+			ORDER BY id ASC`,
+			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterOldValRange"),
 
 		DeleteSQL: query.New(`
 			DELETE FROM kine
@@ -380,6 +421,19 @@ func (d *Generic) ListCurrent(ctx context.Context, prefix, startKey string, limi
 		}
 		return d.query(ctx, sql, prefix, includeDeleted)
 	}
+	if d.PrefixRange != nil {
+		if low, high, ok := d.PrefixRange(prefix); ok {
+			if keysOnly {
+				sql = d.ListCurrentRangeSQL
+			} else {
+				sql = d.ListCurrentRangeValSQL
+			}
+			if limit > 0 {
+				sql = sql.Appendf("LIMIT %d", limit)
+			}
+			return d.query(ctx, sql, low, high, startKey, includeDeleted)
+		}
+	}
 	prefix = strings.ReplaceAll(prefix, `_`, `^_`)
 	if keysOnly {
 		sql = d.ListCurrentSQL
@@ -393,8 +447,32 @@ func (d *Generic) ListCurrent(ctx context.Context, prefix, startKey string, limi
 }
 
 func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
-	prefix = strings.ReplaceAll(prefix, `_`, `^_`)
 	var sql *query.Named
+	if d.PrefixRange != nil {
+		if low, high, ok := d.PrefixRange(prefix); ok {
+			if startKey == "" {
+				if keysOnly {
+					sql = d.ListRevisionStartRangeSQL
+				} else {
+					sql = d.ListRevisionStartRangeValSQL
+				}
+				if limit > 0 {
+					sql = sql.Appendf("LIMIT %d", limit)
+				}
+				return d.query(ctx, sql, low, high, revision, includeDeleted)
+			}
+			if keysOnly {
+				sql = d.GetRevisionAfterRangeSQL
+			} else {
+				sql = d.GetRevisionAfterRangeValSQL
+			}
+			if limit > 0 {
+				sql = sql.Appendf("LIMIT %d", limit)
+			}
+			return d.query(ctx, sql, low, high, startKey, revision, includeDeleted)
+		}
+	}
+	prefix = strings.ReplaceAll(prefix, `_`, `^_`)
 	if startKey == "" {
 		if keysOnly {
 			sql = d.ListRevisionStartSQL
@@ -423,7 +501,15 @@ func (d *Generic) CountCurrent(ctx context.Context, prefix, startKey string) (in
 		id  int64
 	)
 
-	row := d.queryRow(ctx, d.CountCurrentSQL, prefix, startKey, false)
+	sql := d.CountCurrentSQL
+	args := []interface{}{prefix, startKey, false}
+	if d.PrefixRange != nil {
+		if low, high, ok := d.PrefixRange(prefix); ok {
+			sql = d.CountCurrentRangeSQL
+			args = []interface{}{low, high, startKey, false}
+		}
+	}
+	row := d.queryRow(ctx, sql, args...)
 	err := row.Scan(&rev, &id)
 	return rev.Int64, id, err
 }
@@ -435,7 +521,15 @@ func (d *Generic) Count(ctx context.Context, prefix, startKey string, revision i
 		id      int64
 	)
 
-	row := d.queryRow(ctx, d.CountRevisionSQL, prefix, startKey, revision, false)
+	sql := d.CountRevisionSQL
+	args := []interface{}{prefix, startKey, revision, false}
+	if d.PrefixRange != nil {
+		if low, high, ok := d.PrefixRange(prefix); ok {
+			sql = d.CountRevisionRangeSQL
+			args = []interface{}{low, high, startKey, revision, false}
+		}
+	}
+	row := d.queryRow(ctx, sql, args...)
 	err := row.Scan(&rev, &compact, &id)
 	return rev.Int64, compact.Int64, id, err
 }
@@ -452,14 +546,24 @@ func (d *Generic) CurrentRevision(ctx context.Context) (int64, error) {
 
 func (d *Generic) After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error) {
 	sql := d.AfterOldValSQL
+	args := []interface{}{prefix, rev}
+	if d.PrefixRange != nil {
+		if low, high, ok := d.PrefixRange(prefix); ok {
+			sql = d.AfterOldValRangeSQL
+			args = []interface{}{low, high, rev}
+		}
+	}
 	if limit > 0 {
 		sql = sql.Appendf("LIMIT %d", limit)
 	}
-	return d.query(ctx, sql, prefix, rev)
+	return d.query(ctx, sql, args...)
 }
 
 func (d *Generic) PrepareAfter(ctx context.Context, limit int64) (*query.Stmt, error) {
 	sql := d.AfterOldValSQL
+	if d.PrefixRange != nil {
+		sql = d.AfterOldValRangeSQL
+	}
 	if limit > 0 {
 		sql = sql.Appendf("LIMIT %d", limit)
 	}
@@ -467,6 +571,12 @@ func (d *Generic) PrepareAfter(ctx context.Context, limit int64) (*query.Stmt, e
 }
 
 func (d *Generic) QueryAfter(ctx context.Context, stmt *query.Stmt, prefix string, rev int64) (*sql.Rows, error) {
+	if d.PrefixRange != nil {
+		if low, high, ok := d.PrefixRange(prefix); ok {
+			return d.queryStatement(ctx, stmt, low, high, rev)
+		}
+		return nil, fmt.Errorf("invalid prefix range: %q", prefix)
+	}
 	return d.queryStatement(ctx, stmt, prefix, rev)
 }
 

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -26,7 +27,7 @@ var (
 		`CREATE TABLE IF NOT EXISTS kine
 			(
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				name INTEGER,
+				name TEXT,
 				created INTEGER,
 				deleted INTEGER,
 				create_revision INTEGER,
@@ -73,7 +74,7 @@ func NewVariant(ctx context.Context, wg *sync.WaitGroup, driverName string, cfg 
 		noStartupVacuum = true
 	}
 
-	connector, err := newConnector(driverName, cfg.DataSourceName)
+	connector, err := newConnector(driverName, withCaseSensitiveLike(cfg.DataSourceName))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -132,6 +133,7 @@ func setup(db *sql.DB, noCheckpointing, noAutoCheckpoint, noStartupVacuum bool) 
 		logrus.Infof("WAL auto-checkpoint is disabled")
 		schema = append(schema, `PRAGMA wal_autocheckpoint = 0`)
 	}
+	schema = append(schema, `PRAGMA case_sensitive_like = ON`)
 
 	for _, stmt := range schema {
 		logrus.Tracef("SETUP EXEC : %v", query.Strip(stmt))
@@ -156,6 +158,16 @@ func setup(db *sql.DB, noCheckpointing, noAutoCheckpoint, noStartupVacuum bool) 
 	}
 
 	return nil
+}
+
+func withCaseSensitiveLike(dsn string) string {
+	path, params, _ := strings.Cut(dsn, "?")
+	values, err := url.ParseQuery(params)
+	if err != nil {
+		return dsn
+	}
+	values.Set("_case_sensitive_like", "ON")
+	return path + "?" + values.Encode()
 }
 
 func init() {

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -74,7 +73,7 @@ func NewVariant(ctx context.Context, wg *sync.WaitGroup, driverName string, cfg 
 		noStartupVacuum = true
 	}
 
-	connector, err := newConnector(driverName, withCaseSensitiveLike(cfg.DataSourceName))
+	connector, err := newConnector(driverName, cfg.DataSourceName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,6 +111,7 @@ func NewVariant(ctx context.Context, wg *sync.WaitGroup, driverName string, cfg 
 	}
 	dialect.TranslateErr = translateErr
 	dialect.ErrCode = errCode
+	dialect.PrefixRange = prefixRange
 
 	if err := setup(dialect.DB, noCompactCheckpoint, noAutoCheckpoint, noStartupVacuum); err != nil {
 		return nil, nil, fmt.Errorf("setup db: %w", err)
@@ -133,7 +133,6 @@ func setup(db *sql.DB, noCheckpointing, noAutoCheckpoint, noStartupVacuum bool) 
 		logrus.Infof("WAL auto-checkpoint is disabled")
 		schema = append(schema, `PRAGMA wal_autocheckpoint = 0`)
 	}
-	schema = append(schema, `PRAGMA case_sensitive_like = ON`)
 
 	for _, stmt := range schema {
 		logrus.Tracef("SETUP EXEC : %v", query.Strip(stmt))
@@ -160,14 +159,53 @@ func setup(db *sql.DB, noCheckpointing, noAutoCheckpoint, noStartupVacuum bool) 
 	return nil
 }
 
-func withCaseSensitiveLike(dsn string) string {
-	path, params, _ := strings.Cut(dsn, "?")
-	values, err := url.ParseQuery(params)
-	if err != nil {
-		return dsn
+func prefixRange(pattern string) (string, string, bool) {
+	prefix, ok := strings.CutSuffix(pattern, "%")
+	if !ok {
+		return "", "", false
 	}
-	values.Set("_case_sensitive_like", "ON")
-	return path + "?" + values.Encode()
+
+	low, ok := unescapeLikePrefix(prefix)
+	if !ok || low == "" {
+		return "", "", false
+	}
+
+	high := []byte(low)
+	for i := len(high) - 1; i >= 0; i-- {
+		if high[i] != 0xff {
+			high[i]++
+			return low, string(high[:i+1]), true
+		}
+	}
+
+	return "", "", false
+}
+
+func unescapeLikePrefix(pattern string) (string, bool) {
+	var b strings.Builder
+	b.Grow(len(pattern))
+
+	escaped := false
+	for _, r := range pattern {
+		if escaped {
+			b.WriteRune(r)
+			escaped = false
+			continue
+		}
+		switch r {
+		case '^':
+			escaped = true
+		case '%':
+			return "", false
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if escaped {
+		b.WriteRune('^')
+	}
+
+	return b.String(), true
 }
 
 func init() {

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -60,8 +60,6 @@ func translateDSN(dsn string) (string, error) {
 			addAll("_pragma", "journal_mode(%s)", vals)
 		case "_synchronous", "_sync":
 			addAll("_pragma", "synchronous(%s)", vals)
-		case "_case_sensitive_like", "_cslike":
-			addAll("_pragma", "case_sensitive_like(%s)", vals)
 		case "cache":
 			// shared cache mode is not supported
 		default:

--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -60,6 +60,8 @@ func translateDSN(dsn string) (string, error) {
 			addAll("_pragma", "journal_mode(%s)", vals)
 		case "_synchronous", "_sync":
 			addAll("_pragma", "synchronous(%s)", vals)
+		case "_case_sensitive_like", "_cslike":
+			addAll("_pragma", "case_sensitive_like(%s)", vals)
 		case "cache":
 			// shared cache mode is not supported
 		default:

--- a/pkg/drivers/sqlite/sqlite_test.go
+++ b/pkg/drivers/sqlite/sqlite_test.go
@@ -2,9 +2,23 @@ package sqlite
 
 import (
 	"database/sql"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	connector, err := newConnector("sqlite3", withCaseSensitiveLike(dbPath+"?"+DefaultParams))
+	if err != nil {
+		t.Fatalf("Failed to create connector: %v", err)
+	}
+
+	return sql.OpenDB(connector)
+}
 
 // createBloatedDB creates a temporary SQLite database in WAL mode with the kine
 // schema, inserts rowCount rows, then deletes them all. The deleted pages remain
@@ -14,19 +28,13 @@ import (
 func createBloatedDB(t *testing.T, rowCount int) *sql.DB {
 	t.Helper()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	connector, err := newConnector("sqlite3", dbPath+"?"+DefaultParams)
-	if err != nil {
-		t.Fatalf("Failed to create connector: %v", err)
-	}
-
-	db := sql.OpenDB(connector)
+	db := openTestDB(t)
 
 	// Create the kine table (same schema as production).
-	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS kine
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS kine
 		(
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name INTEGER,
+			name TEXT,
 			created INTEGER,
 			deleted INTEGER,
 			create_revision INTEGER,
@@ -52,7 +60,7 @@ func createBloatedDB(t *testing.T, rowCount int) *sql.DB {
 	}
 
 	for i := range rowCount {
-		if _, err := stmt.Exec(i); err != nil {
+		if _, err := stmt.Exec(fmt.Sprintf("/registry/test/%d", i)); err != nil {
 			t.Fatalf("failed to insert row %d: %v", i, err)
 		}
 	}
@@ -91,6 +99,63 @@ func freelistCount(t *testing.T, db *sql.DB) int64 {
 	}
 
 	return count
+}
+
+func TestSetupCreatesTextNameColumn(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	if err := setup(db, false, false, true); err != nil {
+		t.Fatalf("setup() failed: %v", err)
+	}
+
+	rows, err := db.Query(`PRAGMA table_info(kine)`)
+	if err != nil {
+		t.Fatalf("failed to query table info: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			typ     string
+			notNull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dflt, &pk); err != nil {
+			t.Fatalf("failed to scan table info: %v", err)
+		}
+		if name == "name" {
+			if !strings.EqualFold(typ, "TEXT") {
+				t.Fatalf("expected kine.name to be TEXT, got %q", typ)
+			}
+			return
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("failed to read table info: %v", err)
+	}
+
+	t.Fatal("kine.name column not found")
+}
+
+func TestSetupEnablesCaseSensitiveLike(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	if err := setup(db, false, false, true); err != nil {
+		t.Fatalf("setup() failed: %v", err)
+	}
+
+	var matches bool
+	if err := db.QueryRow(`SELECT 'a' LIKE 'A'`).Scan(&matches); err != nil {
+		t.Fatalf("failed to query LIKE behavior: %v", err)
+	}
+	if matches {
+		t.Fatal("expected LIKE to be case-sensitive after setup")
+	}
 }
 
 func TestSetupVacuumReclaimsDiskSpace(t *testing.T) {

--- a/pkg/drivers/sqlite/sqlite_test.go
+++ b/pkg/drivers/sqlite/sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -12,7 +13,7 @@ func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
-	connector, err := newConnector("sqlite3", withCaseSensitiveLike(dbPath+"?"+DefaultParams))
+	connector, err := newConnector("sqlite3", dbPath+"?"+DefaultParams)
 	if err != nil {
 		t.Fatalf("Failed to create connector: %v", err)
 	}
@@ -141,7 +142,54 @@ func TestSetupCreatesTextNameColumn(t *testing.T) {
 	t.Fatal("kine.name column not found")
 }
 
-func TestSetupEnablesCaseSensitiveLike(t *testing.T) {
+func TestPrefixRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		low     string
+		high    string
+		ok      bool
+	}{
+		{
+			name:    "resource prefix",
+			pattern: "/registry/pods/%",
+			low:     "/registry/pods/",
+			high:    "/registry/pods0",
+			ok:      true,
+		},
+		{
+			name:    "escaped underscore",
+			pattern: "/registry/foo^_/%",
+			low:     "/registry/foo_/",
+			high:    "/registry/foo_0",
+			ok:      true,
+		},
+		{
+			name:    "single key",
+			pattern: "/registry/pods/default",
+			ok:      false,
+		},
+		{
+			name:    "unsupported internal wildcard",
+			pattern: "/registry/%/pods/%",
+			ok:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			low, high, ok := prefixRange(tt.pattern)
+			if ok != tt.ok {
+				t.Fatalf("expected ok=%v, got %v", tt.ok, ok)
+			}
+			if low != tt.low || high != tt.high {
+				t.Fatalf("expected range [%q, %q), got [%q, %q)", tt.low, tt.high, low, high)
+			}
+		})
+	}
+}
+
+func TestPrefixRangeQueryLimitsResults(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
@@ -149,12 +197,48 @@ func TestSetupEnablesCaseSensitiveLike(t *testing.T) {
 		t.Fatalf("setup() failed: %v", err)
 	}
 
-	var matches bool
-	if err := db.QueryRow(`SELECT 'a' LIKE 'A'`).Scan(&matches); err != nil {
-		t.Fatalf("failed to query LIKE behavior: %v", err)
+	names := []string{
+		"/registry/pods/template-0001",
+		"/registry/pods/template-0002",
+		"/registry/pods/template-0003",
+		"/registry/pods0/out",
+		"/registry/podr/out",
 	}
-	if matches {
-		t.Fatal("expected LIKE to be case-sensitive after setup")
+	for i, name := range names {
+		if _, err := db.Exec(`INSERT INTO kine (name, created, deleted, create_revision, prev_revision, lease) VALUES (?, 1, 0, ?, 0, 0)`, name, i+1); err != nil {
+			t.Fatalf("failed to insert %q: %v", name, err)
+		}
+	}
+
+	low, high, ok := prefixRange("/registry/pods/%")
+	if !ok {
+		t.Fatal("expected prefix range")
+	}
+	rows, err := db.Query(`SELECT name FROM kine WHERE name >= ? AND name < ? ORDER BY name ASC`, low, high)
+	if err != nil {
+		t.Fatalf("failed to query range: %v", err)
+	}
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("failed to scan name: %v", err)
+		}
+		got = append(got, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("failed to read names: %v", err)
+	}
+
+	want := []string{
+		"/registry/pods/template-0001",
+		"/registry/pods/template-0002",
+		"/registry/pods/template-0003",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected names %v, got %v", want, got)
 	}
 }
 


### PR DESCRIPTION
Closes k3s-io/kine#690.

## Summary
- Declare the SQLite `kine.name` column as `TEXT` for newly created databases.
- Enable `case_sensitive_like` for SQLite connections so prefix LIKE queries can use range scans.
- Translate the same setting for the modernc/sqlite no-cgo driver path.
- Add SQLite setup tests for the column type and LIKE behavior.

## Verification
- `gofmt -w pkg/drivers/sqlite/sqlite.go pkg/drivers/sqlite/sqlite_nocgo.go pkg/drivers/sqlite/sqlite_test.go`
- `go test ./pkg/drivers/sqlite`
- `CGO_ENABLED=0 go test ./pkg/drivers/sqlite`
- `git diff --check`