### PR TITLE
Drop PREFIX, START conversions in favor of native KEY, END

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -38,12 +38,15 @@ var (
 		WHERE (deleted = 0 OR ?)
 		ORDER BY name ASC
 		`
-	CurrentRevSQL = `SELECT MAX(id) AS current_rev FROM kine`
-	CompactRevSQL = `SELECT MAX(prev_revision) AS compact_rev FROM kine WHERE name = 'compact_rev_key'`
-	FiltersRevSQL = `SELECT MAX(id) AS id FROM kine WHERE name LIKE ? ESCAPE '^' %s GROUP BY name`
+	CurrentRevSQL  = `SELECT MAX(id) AS current_rev FROM kine`
+	CompactRevSQL  = `SELECT MAX(prev_revision) AS compact_rev FROM kine WHERE name = 'compact_rev_key'`
+	BetweenNameSQL = `SELECT MAX(id) AS id FROM kine WHERE name >= ? AND name < ? %s GROUP BY name`
+	EqualsNameSQL  = `SELECT MAX(id) AS id FROM kine WHERE name = ? %s`
 
-	listSQL    = fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, FiltersRevSQL)
-	listValSQL = fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, FiltersRevSQL)
+	listSQL    = fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, BetweenNameSQL)
+	listValSQL = fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, BetweenNameSQL)
+	getSQL     = fmt.Sprintf(ListFmt, Columns, CurrentRevSQL, CompactRevSQL, EqualsNameSQL)
+	getValSQL  = fmt.Sprintf(ListFmt, WithVal, CurrentRevSQL, CompactRevSQL, EqualsNameSQL)
 )
 
 type ErrRetry func(error) bool
@@ -75,6 +78,8 @@ type Generic struct {
 	CountCurrentSQL         *query.Named
 	CountRevisionSQL        *query.Named
 	AfterOldValSQL          *query.Named
+	AfterAllOldValSQL       *query.Named
+	AfterSingleOldValSQL    *query.Named
 	CurrentRevSQL           *query.Named
 	CompactRevSQL           *query.Named
 	DeleteSQL               *query.Named
@@ -188,50 +193,65 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 	return &Generic{
 		DB: db,
 
-		ListCurrentSQL:          query.New(fmt.Sprintf(listSQL, "AND name >= ?"), paramCharacter, numbered, "ListCurrent"),
-		ListCurrentValSQL:       query.New(fmt.Sprintf(listValSQL, "AND name >= ?"), paramCharacter, numbered, "ListCurrentVal"),
-		ListRevisionStartSQL:    query.New(fmt.Sprintf(listSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStart"),
-		ListRevisionStartValSQL: query.New(fmt.Sprintf(listValSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStartVal"),
-		GetRevisionAfterSQL:     query.New(fmt.Sprintf(listSQL, "AND name >= ? AND id <= ?"), paramCharacter, numbered, "GetRevisionAfter"),
-		GetRevisionAfterValSQL:  query.New(fmt.Sprintf(listValSQL, "AND name >= ? AND id <= ?"), paramCharacter, numbered, "GetRevisionAfterVal"),
+		ListCurrentSQL:          query.New(fmt.Sprintf(listSQL, ""), paramCharacter, numbered, "ListCurrent"),
+		ListCurrentValSQL:       query.New(fmt.Sprintf(listValSQL, ""), paramCharacter, numbered, "ListCurrentVal"),
+		ListRevisionStartSQL:    query.New(fmt.Sprintf(getSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStart"),
+		ListRevisionStartValSQL: query.New(fmt.Sprintf(getValSQL, "AND id <= ?"), paramCharacter, numbered, "ListRevisionStartVal"),
+		GetRevisionAfterSQL:     query.New(fmt.Sprintf(listSQL, "AND id <= ?"), paramCharacter, numbered, "GetRevisionAfter"),
+		GetRevisionAfterValSQL:  query.New(fmt.Sprintf(listValSQL, "AND id <= ?"), paramCharacter, numbered, "GetRevisionAfterVal"),
 		CurrentRevSQL:           query.New(CurrentRevSQL, paramCharacter, numbered, "CurrentRev"),
 		CompactRevSQL:           query.New(CompactRevSQL, paramCharacter, numbered, "CompactRev"),
 
 		GetSingleSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
 			FROM (%s) AS current, (%s) AS compact, kine
-			WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
+			WHERE id = (%s)
 			AND (deleted = 0 OR ?)`,
-			Columns, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "GetSingle"),
+			Columns, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(EqualsNameSQL, "")), paramCharacter, numbered, "GetSingle"),
 
 		GetSingleValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
 			FROM (%s) AS current, (%s) AS compact, kine
-			WHERE id = (SELECT MAX(id) FROM kine WHERE name = ?)
+			WHERE id = (%s)
 			AND (deleted = 0 OR ?)`,
-			WithVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "GetSingleVal"),
+			WithVal, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(EqualsNameSQL, "")), paramCharacter, numbered, "GetSingleVal"),
 
 		CountCurrentSQL: query.New(fmt.Sprintf(`
 			SELECT (%s), COUNT(id)
 			FROM kine
 			INNER JOIN (%s) AS mkv USING (id)
 			WHERE (deleted = 0 OR ?)`,
-			CurrentRevSQL, fmt.Sprintf(FiltersRevSQL, "AND name >= ?")), paramCharacter, numbered, "CountCurrent"),
+			CurrentRevSQL, fmt.Sprintf(BetweenNameSQL, "")), paramCharacter, numbered, "CountCurrent"),
 
 		CountRevisionSQL: query.New(fmt.Sprintf(`
 			SELECT (%s), (%s), COUNT(id)
 			FROM kine
 			INNER JOIN (%s) AS mkv USING (id)
 			WHERE (deleted = 0 OR ?)`,
-			CurrentRevSQL, CompactRevSQL, fmt.Sprintf(FiltersRevSQL, "AND name >= ? AND id <= ?")), paramCharacter, numbered, "CountRevision"),
+			CurrentRevSQL, CompactRevSQL, fmt.Sprintf(BetweenNameSQL, "AND id <= ?")), paramCharacter, numbered, "CountRevision"),
 
 		AfterOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
 			FROM (%s) AS current, (%s) AS compact, kine
-			WHERE	name LIKE ? ESCAPE '^'
+			WHERE	name >= ? AND name < ?
 			AND	id > ?
 			ORDER BY id ASC`,
 			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterOldVal"),
+
+		AfterAllOldValSQL: query.New(fmt.Sprintf(`
+			SELECT current_rev, compact_rev, %s
+			FROM (%s) AS current, (%s) AS compact, kine
+			WHERE id > ?
+			ORDER BY id ASC`,
+			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterAllOldVal"),
+
+		AfterSingleOldValSQL: query.New(fmt.Sprintf(`
+			SELECT current_rev, compact_rev, %s
+			FROM (%s) AS current, (%s) AS compact, kine
+			WHERE name = ?
+			AND id > ?
+			ORDER BY id ASC`,
+			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterSingleOldVal"),
 
 		DeleteSQL: query.New(`
 			DELETE FROM kine
@@ -259,29 +279,6 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 			VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			paramCharacter, numbered, "Fill"),
 	}, err
-}
-
-func (d *Generic) prepare(ctx context.Context, sql *query.Named) (*query.Stmt, error) {
-	logrus.Tracef("PREPARE: %s", sql)
-	conn, err := d.DB.Conn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	stmt, err := conn.PrepareContext(ctx, sql.Query)
-	if err != nil {
-		return nil, err
-	}
-	return &query.Stmt{Named: sql, Stmt: stmt}, nil
-}
-
-func (d *Generic) queryStatement(ctx context.Context, stmt *query.Stmt, args ...any) (result *sql.Rows, err error) {
-	query := stmt.Fill(args)
-	logrus.Tracef("QUERY PREPARED: %s", query)
-	startTime := time.Now()
-	defer func() {
-		metrics.ObserveSQL(startTime, d.ErrCode(err), 0, query)
-	}()
-	return stmt.Stmt.QueryContext(ctx, args...)
 }
 
 func (d *Generic) query(ctx context.Context, sql *query.Named, args ...any) (result *sql.Rows, err error) {
@@ -370,17 +367,16 @@ func (d *Generic) DeleteRevision(ctx context.Context, revision int64) error {
 	return err
 }
 
-func (d *Generic) ListCurrent(ctx context.Context, prefix, startKey string, limit int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
+func (d *Generic) ListCurrent(ctx context.Context, key, end string, limit int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
 	var sql *query.Named
-	if startKey == "" && !strings.HasSuffix(prefix, "%") {
+	if end == "" {
 		if keysOnly {
 			sql = d.GetSingleSQL
 		} else {
 			sql = d.GetSingleValSQL
 		}
-		return d.query(ctx, sql, prefix, includeDeleted)
+		return d.query(ctx, sql, key, includeDeleted)
 	}
-	prefix = strings.ReplaceAll(prefix, `_`, `^_`)
 	if keysOnly {
 		sql = d.ListCurrentSQL
 	} else {
@@ -389,13 +385,12 @@ func (d *Generic) ListCurrent(ctx context.Context, prefix, startKey string, limi
 	if limit > 0 {
 		sql = sql.Appendf("LIMIT %d", limit)
 	}
-	return d.query(ctx, sql, prefix, startKey, includeDeleted)
+	return d.query(ctx, sql, key, end, includeDeleted)
 }
 
-func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
-	prefix = strings.ReplaceAll(prefix, `_`, `^_`)
+func (d *Generic) List(ctx context.Context, key, end string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error) {
 	var sql *query.Named
-	if startKey == "" {
+	if end == "" {
 		if keysOnly {
 			sql = d.ListRevisionStartSQL
 		} else {
@@ -404,7 +399,7 @@ func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revi
 		if limit > 0 {
 			sql = sql.Appendf("LIMIT %d", limit)
 		}
-		return d.query(ctx, sql, prefix, revision, includeDeleted)
+		return d.query(ctx, sql, key, revision, includeDeleted)
 	}
 	if keysOnly {
 		sql = d.GetRevisionAfterSQL
@@ -414,28 +409,28 @@ func (d *Generic) List(ctx context.Context, prefix, startKey string, limit, revi
 	if limit > 0 {
 		sql = sql.Appendf("LIMIT %d", limit)
 	}
-	return d.query(ctx, sql, prefix, startKey, revision, includeDeleted)
+	return d.query(ctx, sql, key, end, revision, includeDeleted)
 }
 
-func (d *Generic) CountCurrent(ctx context.Context, prefix, startKey string) (int64, int64, error) {
+func (d *Generic) CountCurrent(ctx context.Context, key, end string) (int64, int64, error) {
 	var (
 		rev sql.NullInt64
 		id  int64
 	)
 
-	row := d.queryRow(ctx, d.CountCurrentSQL, prefix, startKey, false)
+	row := d.queryRow(ctx, d.CountCurrentSQL, key, end, false)
 	err := row.Scan(&rev, &id)
 	return rev.Int64, id, err
 }
 
-func (d *Generic) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, int64, error) {
+func (d *Generic) Count(ctx context.Context, key, end string, revision int64) (int64, int64, int64, error) {
 	var (
 		rev     sql.NullInt64
 		compact sql.NullInt64
 		id      int64
 	)
 
-	row := d.queryRow(ctx, d.CountRevisionSQL, prefix, startKey, revision, false)
+	row := d.queryRow(ctx, d.CountRevisionSQL, key, end, revision, false)
 	err := row.Scan(&rev, &compact, &id)
 	return rev.Int64, compact.Int64, id, err
 }
@@ -450,24 +445,27 @@ func (d *Generic) CurrentRevision(ctx context.Context) (int64, error) {
 	return id, err
 }
 
-func (d *Generic) After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error) {
-	sql := d.AfterOldValSQL
+func (d *Generic) After(ctx context.Context, key, end string, rev, limit int64) (*sql.Rows, error) {
+	var sql *query.Named
+	if key == "" {
+		sql = d.AfterAllOldValSQL
+		if limit > 0 {
+			sql = sql.Appendf("LIMIT %d", limit)
+		}
+		return d.query(ctx, sql, rev)
+	}
+	if end == "" {
+		sql = d.AfterSingleOldValSQL
+		if limit > 0 {
+			sql = sql.Appendf("LIMIT %d", limit)
+		}
+		return d.query(ctx, sql, key, rev)
+	}
+	sql = d.AfterOldValSQL
 	if limit > 0 {
 		sql = sql.Appendf("LIMIT %d", limit)
 	}
-	return d.query(ctx, sql, prefix, rev)
-}
-
-func (d *Generic) PrepareAfter(ctx context.Context, limit int64) (*query.Stmt, error) {
-	sql := d.AfterOldValSQL
-	if limit > 0 {
-		sql = sql.Appendf("LIMIT %d", limit)
-	}
-	return d.prepare(ctx, sql)
-}
-
-func (d *Generic) QueryAfter(ctx context.Context, stmt *query.Stmt, prefix string, rev int64) (*sql.Rows, error) {
-	return d.queryStatement(ctx, stmt, prefix, rev)
+	return d.query(ctx, sql, key, end, rev)
 }
 
 func (d *Generic) Fill(ctx context.Context, revision int64) error {

--- a/pkg/drivers/memory/memory.go
+++ b/pkg/drivers/memory/memory.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"context"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -183,8 +182,8 @@ func (m *Memory) logIndexAfter(rev int64) int {
 }
 
 // Get returns the current revision and the KeyValue for the given key.
-func (m *Memory) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *server.KeyValue, error) {
-	rev, kvs, err := m.List(ctx, key, rangeEnd, limit, revision, keysOnly)
+func (m *Memory) Get(ctx context.Context, key string, revision int64, keysOnly bool) (int64, *server.KeyValue, error) {
+	rev, kvs, err := m.List(ctx, key, "", 1, revision, keysOnly)
 	if err != nil {
 		return rev, nil, err
 	}
@@ -274,7 +273,7 @@ func (m *Memory) Delete(ctx context.Context, key string, revision int64) (int64,
 	return rev, latest.toKeyValue(), true, nil
 }
 
-func (m *Memory) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (int64, []*server.KeyValue, error) {
+func (m *Memory) List(ctx context.Context, key, end string, limit, revision int64, keysOnly bool) (int64, []*server.KeyValue, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -289,19 +288,15 @@ func (m *Memory) List(ctx context.Context, prefix, startKey string, limit, revis
 		rev = revision
 	}
 
-	seek, exact := seekKey(prefix, startKey)
 	iter := m.keys.Iter()
-	if !iter.Seek(seek) {
+	if !iter.Seek(key) {
 		return rev, nil, nil
 	}
 
 	var kvs []*server.KeyValue
 	for {
 		k := iter.Key()
-		if exact && k != seek {
-			break
-		}
-		if !strings.HasPrefix(k, prefix) {
+		if (end == "" && k != key) || (end != "" && k >= end) {
 			break
 		}
 
@@ -331,15 +326,15 @@ func (m *Memory) List(ctx context.Context, prefix, startKey string, limit, revis
 	return rev, kvs, nil
 }
 
-func (m *Memory) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error) {
-	rev, kvs, err := m.List(ctx, prefix, startKey, 0, revision, true)
+func (m *Memory) Count(ctx context.Context, key, end string, revision int64) (int64, int64, error) {
+	rev, kvs, err := m.List(ctx, key, end, 0, revision, true)
 	if err != nil {
 		return rev, 0, err
 	}
 	return rev, int64(len(kvs)), nil
 }
 
-func (m *Memory) Watch(ctx context.Context, prefix string, startRevision int64) server.WatchResult {
+func (m *Memory) Watch(ctx context.Context, key, end string, startRevision int64) server.WatchResult {
 	m.mu.RLock()
 	compactRev := m.compactRevision
 	m.mu.RUnlock()
@@ -375,22 +370,18 @@ func (m *Memory) Watch(ctx context.Context, prefix string, startRevision int64) 
 			var batch []*server.Event
 			for i := m.logIndexAfter(lastSeen); i < len(m.log); i++ {
 				e := m.log[i]
-				if !strings.HasPrefix(e.key, prefix) {
-					lastSeen = e.revision
-					continue
+				if key == "" || (end != "" && e.key >= key && e.key < end) || e.key == key {
+					event := &server.Event{
+						Create: e.created,
+						Delete: e.deleted,
+						KV:     e.toKeyValue(),
+						PrevKV: &server.KeyValue{ModRevision: e.prevRevision},
+					}
+					if e.prev != nil {
+						event.PrevKV = e.prev.toKeyValue()
+					}
+					batch = append(batch, event)
 				}
-
-				event := &server.Event{
-					Create: e.created,
-					Delete: e.deleted,
-					KV:     e.toKeyValue(),
-					PrevKV: &server.KeyValue{ModRevision: e.prevRevision},
-				}
-				if e.prev != nil {
-					event.PrevKV = e.prev.toKeyValue()
-				}
-
-				batch = append(batch, event)
 				lastSeen = e.revision
 			}
 			m.mu.RUnlock()
@@ -493,17 +484,4 @@ func (m *Memory) Compact(ctx context.Context, revision int64) (int64, error) {
 
 	m.compactRevision = revision
 	return rev, nil
-}
-
-// seekKey returns the BTree seek target for a List/Range query and a flag
-// indicating whether the iteration should match the seek key exactly. When
-// startKey is empty (or equal to prefix), iteration begins at prefix; if
-// prefix has no trailing slash this is treated as an exact-key lookup.
-// Otherwise startKey is normalized into the prefix's namespace and used as
-// the resume point for paginated range scans.
-func seekKey(prefix, startKey string) (string, bool) {
-	if startKey == "" {
-		return prefix, true
-	}
-	return strings.TrimSuffix(startKey, "/"), false
 }

--- a/pkg/drivers/memory/memory_test.go
+++ b/pkg/drivers/memory/memory_test.go
@@ -91,7 +91,7 @@ func TestCreate(t *testing.T) {
 	noErr(t, err)
 	expEqual(t, int64(3), rev)
 
-	_, count, err := b.Count(ctx, "/test/", "/test/", 0)
+	_, count, err := b.Count(ctx, "/test/", "/test0", 0)
 	noErr(t, err)
 	expEqual(t, int64(3), count)
 }
@@ -110,7 +110,7 @@ func TestCreateAfterDelete(t *testing.T) {
 	noErr(t, err)
 	expEqual(t, int64(3), rev)
 
-	_, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	_, kv, err := b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, "v2", string(kv.Value))
 	expEqual(t, int64(3), kv.CreateRevision)
@@ -123,7 +123,7 @@ func TestGet(t *testing.T) {
 	_, err := b.Create(ctx, "/test/a", []byte("b"), 5)
 	noErr(t, err)
 
-	rev, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	rev, kv, err := b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, int64(1), rev)
 	expEqual(t, "/test/a", kv.Key)
@@ -132,13 +132,13 @@ func TestGet(t *testing.T) {
 	expEqual(t, int64(1), kv.ModRevision)
 	expEqual(t, int64(1), kv.CreateRevision)
 
-	_, kv, err = b.Get(ctx, "/test/nonexistent", "", 0, 0, false)
+	_, kv, err = b.Get(ctx, "/test/nonexistent", 0, false)
 	noErr(t, err)
 	if kv != nil {
 		t.Fatal("expected nil for nonexistent key")
 	}
 
-	_, _, err = b.Get(ctx, "/test/a", "", 0, 20, false)
+	_, _, err = b.Get(ctx, "/test/a", 20, false)
 	expEqualErr(t, server.ErrFutureRev, err)
 }
 
@@ -151,12 +151,12 @@ func TestGetAtRevision(t *testing.T) {
 	_, _, _, err = b.Update(ctx, "/test/a", []byte("v2"), rev1, 0)
 	noErr(t, err)
 
-	rev, kv, err := b.Get(ctx, "/test/a", "", 0, rev1, false)
+	rev, kv, err := b.Get(ctx, "/test/a", rev1, false)
 	noErr(t, err)
 	expEqual(t, rev1, rev)
 	expEqual(t, "v1", string(kv.Value))
 
-	rev, kv, err = b.Get(ctx, "/test/a", "", 0, 0, false)
+	rev, kv, err = b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, int64(2), rev)
 	expEqual(t, "v2", string(kv.Value))
@@ -251,28 +251,28 @@ func TestList(t *testing.T) {
 	b.Create(ctx, "/test/d/b", nil, 0)
 
 	// All keys under prefix.
-	rev, ents, err := b.List(ctx, "/test/", "/test/", 0, 0, false)
+	rev, ents, err := b.List(ctx, "/test/", "/test0", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, int64(7), rev)
 	expEqual(t, 7, len(ents))
 	expSortedKeys(t, ents)
 
 	// Prefix sub-tree.
-	rev, ents, err = b.List(ctx, "/test/a", "/test/a", 0, 0, false)
+	rev, ents, err = b.List(ctx, "/test/a", "/test/b", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, int64(7), rev)
 	expEqual(t, 3, len(ents))
 	expSortedKeys(t, ents)
 
 	// Start key.
-	rev, ents, err = b.List(ctx, "/test/", "/test/b", 0, 0, false)
+	rev, ents, err = b.List(ctx, "/test/b", "/test0", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, int64(7), rev)
 	expEqual(t, 4, len(ents))
 	expSortedKeys(t, ents)
 
 	// At a revision.
-	rev, ents, err = b.List(ctx, "/test/", "/test/", 0, 3, false)
+	rev, ents, err = b.List(ctx, "/test/", "/test0", 0, 3, false)
 	noErr(t, err)
 	expEqual(t, int64(3), rev)
 	expEqual(t, 3, len(ents))
@@ -280,7 +280,7 @@ func TestList(t *testing.T) {
 	expEqualKeys(t, []string{"/test/a", "/test/a/b/c", "/test/b"}, ents)
 
 	// Full list with limit
-	rev, ents, err = b.List(ctx, "/test/", "/test/", 4, 0, false)
+	rev, ents, err = b.List(ctx, "/test/", "/test0", 4, 0, false)
 	noErr(t, err)
 	expEqual(t, int64(7), rev)
 	expEqual(t, 4, len(ents))
@@ -288,7 +288,7 @@ func TestList(t *testing.T) {
 	expEqualKeys(t, []string{"/test/a", "/test/a/b", "/test/a/b/c", "/test/b"}, ents)
 
 	// Start key with range.
-	rev, ents, err = b.List(ctx, "/test/", "/test/c", 0, 0, false)
+	rev, ents, err = b.List(ctx, "/test/c", "/test0", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, int64(7), rev)
 	expEqual(t, 3, len(ents))
@@ -303,7 +303,7 @@ func TestListExcludesDeleted(t *testing.T) {
 	b.Create(ctx, "/test/b", []byte("val"), 0)
 	b.Delete(ctx, "/test/a", rev)
 
-	_, ents, err := b.List(ctx, "/test/", "/test/", 0, 0, false)
+	_, ents, err := b.List(ctx, "/test/", "/test0", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, 1, len(ents))
 	expEqual(t, "/test/b", ents[0].Key)
@@ -316,13 +316,13 @@ func TestCount(t *testing.T) {
 	b.Create(ctx, "/test/b", nil, 0)
 	b.Create(ctx, "/test/c", nil, 0)
 
-	rev, count, err := b.Count(ctx, "/test/", "/test/", 0)
+	rev, count, err := b.Count(ctx, "/test/", "/test0", 0)
 	noErr(t, err)
 	expEqual(t, int64(3), rev)
 	expEqual(t, int64(3), count)
 
 	// Count at an earlier revision.
-	_, count, err = b.Count(ctx, "/test/", "/test/", 2)
+	_, count, err = b.Count(ctx, "/test/", "/test0", 2)
 	noErr(t, err)
 	expEqual(t, int64(2), count)
 }
@@ -338,7 +338,7 @@ func TestWatch(t *testing.T) {
 
 	// Watch all events from the beginning.
 	wctx, cancel := context.WithCancel(ctx)
-	wr := b.Watch(wctx, "/", 1)
+	wr := b.Watch(wctx, "/", "0", 1)
 	time.Sleep(20 * time.Millisecond)
 	cancel()
 
@@ -350,7 +350,7 @@ func TestWatch(t *testing.T) {
 
 	// Watch filtered by prefix.
 	wctx, cancel = context.WithCancel(ctx)
-	wr = b.Watch(wctx, "/test/a/", 1)
+	wr = b.Watch(wctx, "/test/a/", "/test/a0", 1)
 	time.Sleep(20 * time.Millisecond)
 	cancel()
 
@@ -367,7 +367,7 @@ func TestWatchNewEvents(t *testing.T) {
 	wctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	wr := b.Watch(wctx, "/test/", 0)
+	wr := b.Watch(wctx, "/test/", "/test0", 0)
 
 	// Write after watch starts.
 	b.Create(ctx, "/test/a", []byte("hello"), 0)
@@ -390,7 +390,7 @@ func TestWatchPrevKV(t *testing.T) {
 	wctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	wr := b.Watch(wctx, "/test/", 0)
+	wr := b.Watch(wctx, "/test/", "/test0", 0)
 
 	b.Update(ctx, "/test/a", []byte("v2"), rev, 0)
 
@@ -417,16 +417,16 @@ func TestCompact(t *testing.T) {
 	expEqual(t, int64(3), rev)
 
 	// List at compacted revision should fail.
-	_, _, err = b.List(ctx, "/test/", "", 0, 1, false)
+	_, _, err = b.List(ctx, "/test/", "/test0", 0, 1, false)
 	expEqualErr(t, server.ErrCompacted, err)
 
 	// List at current revision should work.
-	_, ents, err := b.List(ctx, "/test/", "/test/", 0, 0, false)
+	_, ents, err := b.List(ctx, "/test/", "/test0", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, 3, len(ents))
 
 	// List at the compact boundary should work.
-	_, ents, err = b.List(ctx, "/test/", "/test/", 0, 2, false)
+	_, ents, err = b.List(ctx, "/test/", "/test0", 0, 2, false)
 	noErr(t, err)
 	expEqual(t, 2, len(ents))
 }
@@ -464,7 +464,7 @@ func TestCompactTrimsHistory(t *testing.T) {
 	}
 
 	// Latest values are still readable at the current revision.
-	_, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	_, kv, err := b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, "v3", string(kv.Value))
 
@@ -555,7 +555,7 @@ func TestWatchCompacted(t *testing.T) {
 	b.Create(ctx, "/test/b", nil, 0)
 	b.Compact(ctx, 2)
 
-	wr := b.Watch(ctx, "/test/", 1)
+	wr := b.Watch(ctx, "/test/", "/test0", 1)
 	expEqual(t, int64(2), wr.CompactRevision)
 
 	// Events channel should be closed immediately.
@@ -599,7 +599,7 @@ func TestKeysOnly(t *testing.T) {
 	b.Create(ctx, "/test/a", []byte("value-a"), 0)
 	b.Create(ctx, "/test/b", []byte("value-b"), 0)
 
-	_, ents, err := b.List(ctx, "/test/", "/test/", 0, 0, true)
+	_, ents, err := b.List(ctx, "/test/", "/test0", 0, 0, true)
 	noErr(t, err)
 	expEqual(t, 2, len(ents))
 	for _, kv := range ents {
@@ -614,17 +614,17 @@ func TestVersionIncrement(t *testing.T) {
 
 	rev, _ := b.Create(ctx, "/test/a", []byte("v1"), 0)
 
-	_, kv, err := b.Get(ctx, "/test/a", "", 0, 0, false)
+	_, kv, err := b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, int64(1), kv.Version)
 
 	rev, _, _, _ = b.Update(ctx, "/test/a", []byte("v2"), rev, 0)
-	_, kv, err = b.Get(ctx, "/test/a", "", 0, 0, false)
+	_, kv, err = b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, int64(2), kv.Version)
 
 	b.Update(ctx, "/test/a", []byte("v3"), rev, 0)
-	_, kv, err = b.Get(ctx, "/test/a", "", 0, 0, false)
+	_, kv, err = b.Get(ctx, "/test/a", 0, false)
 	noErr(t, err)
 	expEqual(t, int64(3), kv.Version)
 }
@@ -655,7 +655,7 @@ func TestTTLExpiration(t *testing.T) {
 	}
 
 	// All keys should be present immediately after creation.
-	_, ents, err := b.List(ctx, "/test/", "/test/", 0, 0, false)
+	_, ents, err := b.List(ctx, "/test/", "/test0", 0, 0, false)
 	noErr(t, err)
 	expEqual(t, len(leases), len(ents))
 
@@ -667,7 +667,7 @@ func TestTTLExpiration(t *testing.T) {
 	for i, k := range keys {
 		deadline := start.Add(time.Duration(k.lease)*time.Second + grace)
 		for {
-			_, kv, err := b.Get(ctx, k.key, "", 0, 0, false)
+			_, kv, err := b.Get(ctx, k.key, 0, false)
 			noErr(t, err)
 			if kv == nil {
 				break
@@ -687,7 +687,7 @@ func TestTTLExpiration(t *testing.T) {
 			if elapsed >= time.Duration(next.lease)*time.Second {
 				continue
 			}
-			_, kv, err := b.Get(ctx, next.key, "", 0, 0, false)
+			_, kv, err := b.Get(ctx, next.key, 0, false)
 			noErr(t, err)
 			if kv == nil {
 				t.Fatalf("key %s with lease=%ds removed prematurely at %v",
@@ -698,7 +698,7 @@ func TestTTLExpiration(t *testing.T) {
 
 	// After the longest lease has expired plus a grace period, nothing
 	// should remain under /test/.
-	_, ents, err = b.List(ctx, "/test/", "", 0, 0, false)
+	_, ents, err = b.List(ctx, "/test/", "/test0", 0, 0, false)
 	noErr(t, err)
 	if len(ents) != 0 {
 		t.Fatalf("expected /test/ to be empty after all leases expired, got %d keys", len(ents))

--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -145,8 +145,8 @@ func (b *Backend) CurrentRevision(ctx context.Context) (int64, error) {
 }
 
 // Count returns an exact count of the number of matching keys and the current revision of the database.
-func (b *Backend) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error) {
-	count, err := b.kv.Count(ctx, prefix, startKey, revision)
+func (b *Backend) Count(ctx context.Context, key, end string, revision int64) (int64, int64, error) {
+	count, err := b.kv.Count(ctx, key, end, revision)
 	if err != nil {
 		return b.kv.BucketRevision(), 0, err
 	}
@@ -163,8 +163,8 @@ func (b *Backend) Count(ctx context.Context, prefix, startKey string, revision i
 
 // Get returns the store's current revision, the associated server.KeyValue or an error.
 // Mirrors etcd and other drivers by being a list call with a single return
-func (b *Backend) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *server.KeyValue, error) {
-	rev, kvs, err := b.List(ctx, key, rangeEnd, limit, revision, keysOnly)
+func (b *Backend) Get(ctx context.Context, key string, revision int64, keysOnly bool) (int64, *server.KeyValue, error) {
+	rev, kvs, err := b.List(ctx, key, "", 1, revision, keysOnly)
 	if err != nil {
 		return rev, nil, err
 	}
@@ -382,14 +382,14 @@ func (b *Backend) Update(ctx context.Context, key string, value []byte, revision
 	return int64(seq), nv.KV, true, nil
 }
 
-// List returns a range of keys starting with the prefix.
+// List returns a range of keys starting with the key.
 // This would translated to one or more tokens, e.g. `a.b.c`.
-// The startKey would be the next set of tokens that follow the prefix
+// The startKey would be the next set of tokens that follow the key
 // that are alphanumerically equal to or greater than the startKey.
 // If limit is provided, the maximum set of matches is limited.
 // If revision is provided, this indicates the maximum revision to return.
-func (b *Backend) List(ctx context.Context, prefix, startKey string, limit, maxRevision int64, keysOnly bool) (int64, []*server.KeyValue, error) {
-	matches, err := b.kv.List(ctx, prefix, startKey, limit, maxRevision, keysOnly)
+func (b *Backend) List(ctx context.Context, key, end string, limit, maxRevision int64, keysOnly bool) (int64, []*server.KeyValue, error) {
+	matches, err := b.kv.List(ctx, key, end, limit, maxRevision, keysOnly)
 	if err != nil {
 		return b.kv.BucketRevision(), nil, err
 	}
@@ -415,7 +415,7 @@ func (b *Backend) List(ctx context.Context, prefix, startKey string, limit, maxR
 	return rev, kvs, nil
 }
 
-func (b *Backend) Watch(ctx context.Context, prefix string, startRevision int64) server.WatchResult {
+func (b *Backend) Watch(ctx context.Context, key, end string, startRevision int64) server.WatchResult {
 	events := make(chan []*server.Event, 32)
 
 	if startRevision > 0 && startRevision <= b.kv.compactRev.Load() {
@@ -434,14 +434,14 @@ func (b *Backend) Watch(ctx context.Context, prefix string, startRevision int64)
 	outer:
 		for {
 			var err error
-			w, err = b.kv.Watch(ctx, prefix, startRevision)
+			w, err = b.kv.Watch(ctx, key, end, startRevision)
 			if err == nil {
 				break
 			} else if errors.Is(err, context.Canceled) || errors.Is(err, nats.ErrConnectionClosed) {
 				return
 			}
 
-			b.l.Warnf("watch init: prefix=%s, err=%s", prefix, err)
+			b.l.Warnf("watch init: key=%s, err=%s", key, err)
 			time.Sleep(time.Second)
 		}
 		defer w.Stop()
@@ -453,18 +453,18 @@ func (b *Backend) Watch(ctx context.Context, prefix string, startRevision int64)
 				if err == nil || errors.Is(err, context.Canceled) {
 					return
 				}
-				b.l.Debugf("watch ctx: prefix=%s, err=%s", prefix, err)
+				b.l.Debugf("watch ctx: key=%s, err=%s", key, err)
 				err = w.Stop()
 				if err != nil {
-					b.l.Debugf("watch stop: prefix=%s, err=%s", prefix, err)
+					b.l.Debugf("watch stop: key=%s, err=%s", key, err)
 				}
 				goto outer
 
 			case err := <-w.Err():
-				b.l.Debugf("watch error: prefix=%s, err=%s", prefix, err)
+				b.l.Debugf("watch error: key=%s, err=%s", key, err)
 				err = w.Stop()
 				if err != nil {
-					b.l.Debugf("watch stop: prefix=%s, err=%s", prefix, err)
+					b.l.Debugf("watch stop: key=%s, err=%s", key, err)
 				}
 				goto outer
 
@@ -597,7 +597,7 @@ func (b *Backend) compactor() {
 func (b *Backend) compactWatcher() {
 	b.l.Infof("Starting compaction watcher")
 
-	w, err := b.kv.Watch(b.ctx, compactRevAPI, 0)
+	w, err := b.kv.Watch(b.ctx, compactRevAPI, "", 0)
 	if err != nil {
 		b.l.Errorf("Failed to configure watch for compact revision: %v", err)
 	}

--- a/pkg/drivers/nats/backend_test.go
+++ b/pkg/drivers/nats/backend_test.go
@@ -98,7 +98,7 @@ func TestBackend_Create(t *testing.T) {
 	noErr(t, err)
 	expEqual(t, baseRev+4, rev)
 
-	srev, count, err := b.Count(ctx, prefix("/"), prefix("/"), 0)
+	srev, count, err := b.Count(ctx, prefix("/"), prefix("0"), 0)
 	noErr(t, err)
 	expEqual(t, baseRev+4, srev)
 	expEqual(t, 4, count)
@@ -111,7 +111,7 @@ func TestBackend_Create(t *testing.T) {
 	noErr(t, err)
 	expEqual(t, baseRev+6, currRev)
 
-	srev, count, err = b.Count(ctx, prefix("/"), prefix(""), 0)
+	srev, count, err = b.Count(ctx, prefix("/"), prefix("0"), 0)
 	noErr(t, err)
 	expEqual(t, baseRev+6, srev)
 	expEqual(t, 3, count)
@@ -120,7 +120,7 @@ func TestBackend_Create(t *testing.T) {
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
 
-	srev, count, err = b.Count(ctx, prefix("/"), prefix("/"), 0)
+	srev, count, err = b.Count(ctx, prefix("/"), prefix("0"), 0)
 	noErr(t, err)
 	expEqual(t, baseRev+7, srev)
 	expEqual(t, 4, count)
@@ -154,7 +154,7 @@ func TestBackend_Get(t *testing.T) {
 	_, err = b.Create(ctx, prefix("/a"), []byte("b"), 1)
 	noErr(t, err)
 
-	srev, ent, err := b.Get(ctx, prefix("/a"), "", 0, 0, false)
+	srev, ent, err := b.Get(ctx, prefix("/a"), 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+1, srev)
 	expEqual(t, prefix("/a"), ent.Key)
@@ -166,15 +166,15 @@ func TestBackend_Get(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	// Latest is gone.
-	_, _, err = b.Get(ctx, prefix("/a"), "", 0, 0, false)
+	_, _, err = b.Get(ctx, prefix("/a"), 0, false)
 	expEqualErr(t, nil, err)
 
 	// Get at a revision will fail also.
-	_, _, err = b.Get(ctx, prefix("/a"), "", 0, 1, false)
+	_, _, err = b.Get(ctx, prefix("/a"), 1, false)
 	expEqualErr(t, nil, err)
 
 	// Get at later revision, does not exist.
-	_, _, err = b.Get(ctx, prefix("/a"), "", 0, 20, false)
+	_, _, err = b.Get(ctx, prefix("/a"), 20, false)
 	expEqualErr(t, kserver.ErrFutureRev, err)
 
 	// Create it again and update it.
@@ -186,7 +186,7 @@ func TestBackend_Get(t *testing.T) {
 	noErr(t, err)
 
 	// Get at prior version.
-	rev, ent, err = b.Get(ctx, prefix("/a"), "", 0, rev, false)
+	rev, ent, err = b.Get(ctx, prefix("/a"), rev, false)
 	noErr(t, err)
 	expEqual(t, baseRev+4, rev) // Should be the requested older revision
 	expEqual(t, prefix("/a"), ent.Key)
@@ -195,7 +195,7 @@ func TestBackend_Get(t *testing.T) {
 	expEqual(t, rev, ent.ModRevision)
 	expEqual(t, rev, ent.CreateRevision)
 
-	rev, ent, err = b.Get(ctx, prefix("/a"), "", 0, 0, false)
+	rev, ent, err = b.Get(ctx, prefix("/a"), 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+5, rev) // Should be the latest revision
 	expEqual(t, "d", string(ent.Value))
@@ -350,28 +350,28 @@ func TestBackend_List(t *testing.T) {
 	_, _ = b.Create(ctx, prefix("/d/b"), nil, 0)
 
 	// List the keys.
-	rev, ents, err := b.List(ctx, prefix("/"), "", 0, 0, false)
+	rev, ents, err := b.List(ctx, prefix("/"), prefix("0"), 0, 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
-	expEqual(t, 0, len(ents))
+	expEqual(t, 7, len(ents))
 	expSortedKeys(t, ents)
 
 	// List the keys with prefix.
-	rev, ents, err = b.List(ctx, prefix("/a"), prefix("/a"), 0, 0, false)
+	rev, ents, err = b.List(ctx, prefix("/a"), prefix("/b"), 0, 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
 	expEqual(t, 3, len(ents))
 	expSortedKeys(t, ents)
 
 	// List the keys >= start key.
-	rev, ents, err = b.List(ctx, prefix("/"), prefix("/b"), 0, 0, false)
+	rev, ents, err = b.List(ctx, prefix("/b"), prefix("0"), 0, 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
 	expEqual(t, 4, len(ents))
 	expSortedKeys(t, ents)
 
 	// List the keys up to a revision.
-	rev, ents, err = b.List(ctx, prefix("/"), prefix("/"), 0, baseRev+3, false)
+	rev, ents, err = b.List(ctx, prefix("/"), prefix("0"), 0, baseRev+3, false)
 	noErr(t, err)
 	expEqual(t, baseRev+3, rev)
 	expEqual(t, 3, len(ents))
@@ -379,7 +379,7 @@ func TestBackend_List(t *testing.T) {
 	expEqualKeys(t, []string{prefix("/a"), prefix("/a/b/c"), prefix("/b")}, ents)
 
 	// List the keys with a limit.
-	rev, ents, err = b.List(ctx, prefix("/"), prefix("/"), 4, 0, false)
+	rev, ents, err = b.List(ctx, prefix("/"), prefix("0"), 4, 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
 	expEqual(t, 4, len(ents)) // expect the requested amount
@@ -387,7 +387,7 @@ func TestBackend_List(t *testing.T) {
 	expEqualKeys(t, []string{prefix("/a"), prefix("/a/b"), prefix("/a/b/c"), prefix("/b")}, ents)
 
 	// List the keys with a limit after some start key.
-	rev, ents, err = b.List(ctx, prefix("/"), prefix("/b"), 2, 0, false)
+	rev, ents, err = b.List(ctx, prefix("/b"), prefix("0"), 2, 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
 	expEqual(t, 2, len(ents))
@@ -395,7 +395,7 @@ func TestBackend_List(t *testing.T) {
 	expEqualKeys(t, []string{prefix("/b"), prefix("/c")}, ents)
 
 	// List the keys after some start key with slash prefix
-	rev, ents, err = b.List(ctx, prefix("/"), prefix("/c"), 0, 0, false)
+	rev, ents, err = b.List(ctx, prefix("/c"), prefix("0"), 0, 0, false)
 	noErr(t, err)
 	expEqual(t, baseRev+7, rev)
 	expEqual(t, 3, len(ents))
@@ -435,7 +435,7 @@ func TestBackend_Watch(t *testing.T) {
 	_, _, _, _ = b.Delete(ctx, prefix("/a"), rev1)
 	_, _, _, _ = b.Update(ctx, prefix("/a/1"), nil, rev2, 0)
 
-	wr := b.Watch(cctx, "/", baseRev+1)
+	wr := b.Watch(cctx, "/", "0", baseRev+1)
 	time.Sleep(20 * time.Millisecond)
 	cancel()
 
@@ -447,7 +447,7 @@ func TestBackend_Watch(t *testing.T) {
 	expEqual(t, 5, len(events))
 
 	cctx, cancel = context.WithCancel(ctx)
-	wr = b.Watch(cctx, prefix("/a/"), baseRev)
+	wr = b.Watch(cctx, prefix("/a/"), prefix("/a0"), baseRev)
 	time.Sleep(20 * time.Millisecond)
 	cancel()
 

--- a/pkg/drivers/nats/kv.go
+++ b/pkg/drivers/nats/kv.go
@@ -175,7 +175,9 @@ func (e *KeyValue) Start(ctx context.Context) {
 			var err error
 			select {
 			case err = <-errch:
-				logrus.Errorf("btree watcher: error: %v", err)
+				if !errors.Is(err, jetstream.ErrServerShutdown) && !errors.Is(err, jetstream.ErrConnectionClosed) {
+					logrus.Errorf("btree watcher: error: %v", err)
+				}
 
 			case <-ctx.Done():
 				logrus.Infof("%s: stopping key value store", e.name)
@@ -322,18 +324,17 @@ type KeyWatcher interface {
 	Err() <-chan error
 }
 
-func (e *KeyValue) Watch(ctx context.Context, keys string, startRev int64) (KeyWatcher, error) {
+func (e *KeyValue) Watch(ctx context.Context, key, end string, startRev int64) (KeyWatcher, error) {
 	// Everything but the last token will be treated as a filter
 	// on the watcher. The last token will used as a deliver-time filter.
-
-	filter := keys
+	filter := key
 
 	if filter != "/" && strings.HasSuffix(filter, "/") {
-		filter = strings.TrimSuffix(keys, "/")
+		filter = strings.TrimSuffix(key, "/")
 	} else {
 		idx := strings.LastIndexByte(filter, '/')
 		if idx > -1 {
-			filter = keys[:idx+1]
+			filter = key[:idx+1]
 		} else {
 			// No '/' prefix in key and no '/' within key.
 			// We should subscribe on the meta subject
@@ -360,11 +361,10 @@ func (e *KeyValue) Watch(ctx context.Context, keys string, startRev int64) (KeyW
 			return
 		}
 
-		key := strings.TrimPrefix(msg.Subject(), subjectPrefix)
-
-		if keys != "" {
-			dkey, err := e.kc.Decode(strings.TrimPrefix(key, "."))
-			if err != nil || (keys != "/" && !strings.HasPrefix(dkey, keys)) {
+		skey := strings.TrimPrefix(msg.Subject(), subjectPrefix)
+		if skey != "" {
+			dkey, err := e.kc.Decode(strings.TrimPrefix(skey, "."))
+			if err != nil || (key == "" && dkey < key) || (end != "" && dkey >= end) {
 				return
 			}
 		}
@@ -384,7 +384,7 @@ func (e *KeyValue) Watch(ctx context.Context, keys string, startRev int64) (KeyW
 			kc: e.kc,
 			vc: e.vc,
 			entry: &kvEntry{
-				key:       key,
+				key:       skey,
 				bucket:    e.nkv.Bucket(),
 				value:     msg.Data(),
 				revision:  md.Sequence.Stream,
@@ -415,7 +415,7 @@ func (e *KeyValue) Watch(ctx context.Context, keys string, startRev int64) (KeyW
 	ci := con.CachedInfo()
 	cctx, err := con.Consume(handler,
 		jetstream.ConsumeErrHandler(func(cctx jetstream.ConsumeContext, err error) {
-			errch <- fmt.Errorf("watch: error consuming from %s: %v", ci.Name, err)
+			errch <- fmt.Errorf("watch: error consuming from %s: %w", ci.Name, err)
 		}),
 	)
 	if err != nil {
@@ -449,17 +449,15 @@ func (e *KeyValue) BucketRevision() int64 {
 	return int64(e.lastSeq.Load())
 }
 
-func (e *KeyValue) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) ([]jetstream.KeyValueEntry, error) {
+func (e *KeyValue) List(ctx context.Context, key, end string, limit, revision int64, keysOnly bool) ([]jetstream.KeyValueEntry, error) {
 	err := e.checkRevision("", revision)
 	if err != nil {
 		return nil, err
 	}
 
-	seekKey, exact := seekKey(prefix, startKey)
-
 	it := e.bt.Iter()
-	if seekKey != "" {
-		if ok := it.Seek(seekKey); !ok {
+	if key != "" {
+		if ok := it.Seek(key); !ok {
 			return nil, nil
 		}
 	}
@@ -469,11 +467,7 @@ func (e *KeyValue) List(ctx context.Context, prefix, startKey string, limit, rev
 	e.btm.RLock()
 	for {
 		k := it.Key()
-		if exact && k != seekKey {
-			break
-		}
-
-		if !strings.HasPrefix(k, prefix) {
+		if (end == "" && k != key) || (end != "" && k >= end) {
 			break
 		}
 
@@ -510,8 +504,8 @@ func (e *KeyValue) List(ctx context.Context, prefix, startKey string, limit, rev
 	return entries, nil
 }
 
-func (e *KeyValue) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, error) {
-	matches, err := e.getListOps(prefix, startKey, revision)
+func (e *KeyValue) Count(ctx context.Context, key, end string, revision int64) (int64, error) {
+	matches, err := e.getListOps(key, end, revision)
 	if err != nil {
 		return 0, err
 	}
@@ -663,7 +657,7 @@ func (e *KeyValue) btreeWatcher(ctx context.Context, hsize int) error {
 	}
 
 	now := time.Now()
-	w, err := e.Watch(ctx, "/", br)
+	w, err := e.Watch(ctx, "/", "", br)
 	if err != nil {
 		return fmt.Errorf("init: %s after %s", err, time.Since(now))
 	}
@@ -672,7 +666,7 @@ func (e *KeyValue) btreeWatcher(ctx context.Context, hsize int) error {
 	for {
 		select {
 		case err := <-w.Err():
-			return fmt.Errorf("error: %s", err)
+			return fmt.Errorf("error: %w", err)
 
 		case x := <-w.Updates():
 			if x == nil {
@@ -737,17 +731,15 @@ func (e *KeyValue) btreeWatcher(ctx context.Context, hsize int) error {
 	}
 }
 
-func (e *KeyValue) getListOps(prefix, startKey string, revision int64) ([]*keySeq, error) {
+func (e *KeyValue) getListOps(key, end string, revision int64) ([]*keySeq, error) {
 	err := e.checkRevision("", revision)
 	if err != nil {
 		return nil, err
 	}
 
-	seekKey, exact := seekKey(prefix, startKey)
-
 	it := e.bt.Iter()
-	if seekKey != "" {
-		if ok := it.Seek(seekKey); !ok {
+	if key != "" {
+		if ok := it.Seek(key); !ok {
 			return nil, nil
 		}
 	}
@@ -757,12 +749,7 @@ func (e *KeyValue) getListOps(prefix, startKey string, revision int64) ([]*keySe
 	e.btm.RLock()
 	for {
 		k := it.Key()
-
-		if exact && k != seekKey {
-			break
-		}
-
-		if !strings.HasPrefix(k, prefix) {
+		if (end == "" && k != key) || (end != "" && k >= end) {
 			break
 		}
 
@@ -815,11 +802,4 @@ func getSeqOp(val []*seqOp, revision int64, allowDeleted bool) *seqOp {
 	}
 
 	return nil
-}
-
-func seekKey(prefix, startKey string) (string, bool) {
-	if startKey == "" {
-		return prefix, true
-	}
-	return strings.TrimSuffix(startKey, "/"), false
 }

--- a/pkg/drivers/nats/logger.go
+++ b/pkg/drivers/nats/logger.go
@@ -29,7 +29,7 @@ func (b *BackendLogger) Start(ctx context.Context) error {
 }
 
 // Get returns the store's current revision, the associated server.KeyValue or an error.
-func (b *BackendLogger) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (revRet int64, kvRet *server.KeyValue, errRet error) {
+func (b *BackendLogger) Get(ctx context.Context, key string, revision int64, keysOnly bool) (revRet int64, kvRet *server.KeyValue, errRet error) {
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
@@ -41,7 +41,7 @@ func (b *BackendLogger) Get(ctx context.Context, key, rangeEnd string, limit, re
 		b.logMethod(dur, fStr, key, revision, revRet, kvRet != nil, size, errRet, dur)
 	}()
 
-	return b.backend.Get(ctx, key, rangeEnd, limit, revision, keysOnly)
+	return b.backend.Get(ctx, key, revision, keysOnly)
 }
 
 // Create attempts to create the key-value entry and returns the revision number.
@@ -67,27 +67,27 @@ func (b *BackendLogger) Delete(ctx context.Context, key string, revision int64) 
 	return b.backend.Delete(ctx, key, revision)
 }
 
-func (b *BackendLogger) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (revRet int64, kvRet []*server.KeyValue, errRet error) {
+func (b *BackendLogger) List(ctx context.Context, key, end string, limit, revision int64, keysOnly bool) (revRet int64, kvRet []*server.KeyValue, errRet error) {
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
-		fStr := "LIST %s, start=%s, limit=%d, rev=%d => rev=%d, kvs=%d, err=%v, duration=%s"
-		b.logMethod(dur, fStr, prefix, startKey, limit, revision, revRet, len(kvRet), errRet, dur)
+		fStr := "LIST %s, end=%s, limit=%d, rev=%d => rev=%d, kvs=%d, err=%v, duration=%s"
+		b.logMethod(dur, fStr, key, end, limit, revision, revRet, len(kvRet), errRet, dur)
 	}()
 
-	return b.backend.List(ctx, prefix, startKey, limit, revision, keysOnly)
+	return b.backend.List(ctx, key, end, limit, revision, keysOnly)
 }
 
 // Count returns an exact count of the number of matching keys and the current revision of the database
-func (b *BackendLogger) Count(ctx context.Context, prefix, startKey string, revision int64) (revRet int64, count int64, err error) {
+func (b *BackendLogger) Count(ctx context.Context, key, end string, revision int64) (revRet int64, count int64, err error) {
 	start := time.Now()
 	defer func() {
 		dur := time.Since(start)
-		fStr := "COUNT %s, start=%s, rev=%d => rev=%d, count=%d, err=%v, duration=%s"
-		b.logMethod(dur, fStr, prefix, startKey, revision, revRet, count, err, dur)
+		fStr := "COUNT %s, end=%s, rev=%d => rev=%d, count=%d, err=%v, duration=%s"
+		b.logMethod(dur, fStr, key, end, revision, revRet, count, err, dur)
 	}()
 
-	return b.backend.Count(ctx, prefix, startKey, revision)
+	return b.backend.Count(ctx, key, end, revision)
 }
 
 func (b *BackendLogger) Update(ctx context.Context, key string, value []byte, revision, lease int64) (revRet int64, kvRet *server.KeyValue, updateRet bool, errRet error) {
@@ -105,8 +105,8 @@ func (b *BackendLogger) Update(ctx context.Context, key string, value []byte, re
 	return b.backend.Update(ctx, key, value, revision, lease)
 }
 
-func (b *BackendLogger) Watch(ctx context.Context, prefix string, revision int64) server.WatchResult {
-	return b.backend.Watch(ctx, prefix, revision)
+func (b *BackendLogger) Watch(ctx context.Context, key, end string, revision int64) server.WatchResult {
+	return b.backend.Watch(ctx, key, end, revision)
 }
 
 // DbSize get the kineBucket size from JetStream.

--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -26,7 +26,7 @@ var (
 		`CREATE TABLE IF NOT EXISTS kine
 			(
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				name INTEGER,
+				name TEXT,
 				created INTEGER,
 				deleted INTEGER,
 				create_revision INTEGER,

--- a/pkg/drivers/t4/backend.go
+++ b/pkg/drivers/t4/backend.go
@@ -72,7 +72,7 @@ func (b *backend) CurrentRevision(_ context.Context) (int64, error) {
 	return b.node.CurrentRevision(), nil
 }
 
-func (b *backend) Get(ctx context.Context, key, _ string, _, revision int64, keysOnly bool) (int64, *kserver.KeyValue, error) {
+func (b *backend) Get(ctx context.Context, key string, revision int64, keysOnly bool) (int64, *kserver.KeyValue, error) {
 	curRev := b.node.CurrentRevision()
 	if revision > 0 && revision > curRev {
 		return curRev, nil, kserver.ErrFutureRev
@@ -130,7 +130,7 @@ func (b *backend) Delete(ctx context.Context, key string, revision int64) (int64
 	return newRev, toServerKV(oldKV, false), deleted, nil
 }
 
-func (b *backend) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (int64, []*kserver.KeyValue, error) {
+func (b *backend) List(ctx context.Context, key, end string, limit, revision int64, keysOnly bool) (int64, []*kserver.KeyValue, error) {
 	curRev := b.node.CurrentRevision()
 	if revision > 0 && revision > curRev {
 		return curRev, nil, kserver.ErrFutureRev
@@ -138,6 +138,7 @@ func (b *backend) List(ctx context.Context, prefix, startKey string, limit, revi
 	if revision > 0 && revision < b.node.CompactRevision() {
 		return curRev, nil, kserver.ErrCompacted
 	}
+	prefix, startKey := translateRange(key, end)
 	opts := readOpts(revision)
 	if startKey != "" {
 		opts = append(opts, t4.WithFromKey(startKey))
@@ -156,7 +157,7 @@ func (b *backend) List(ctx context.Context, prefix, startKey string, limit, revi
 	return curRev, out, nil
 }
 
-func (b *backend) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error) {
+func (b *backend) Count(ctx context.Context, key, end string, revision int64) (int64, int64, error) {
 	curRev := b.node.CurrentRevision()
 	if revision > 0 && revision > curRev {
 		return curRev, 0, kserver.ErrFutureRev
@@ -164,8 +165,9 @@ func (b *backend) Count(ctx context.Context, prefix, startKey string, revision i
 	if revision > 0 && revision < b.node.CompactRevision() {
 		return curRev, 0, kserver.ErrCompacted
 	}
+	prefix, startKey := translateRange(key, end)
 	opts := readOpts(revision)
-	if startKey != "" {
+	if key != "" {
 		opts = append(opts, t4.WithFromKey(startKey))
 	}
 	count, err := b.node.LinearizableCount(ctx, prefix, opts...)
@@ -183,7 +185,7 @@ func (b *backend) Update(ctx context.Context, key string, value []byte, revision
 	return newRev, toServerKV(oldKV, false), updated, nil
 }
 
-func (b *backend) Watch(ctx context.Context, key string, revision int64) kserver.WatchResult {
+func (b *backend) Watch(ctx context.Context, key, end string, revision int64) kserver.WatchResult {
 	curRev := b.node.CurrentRevision()
 	compactRev := b.node.CompactRevision()
 
@@ -197,13 +199,14 @@ func (b *backend) Watch(ctx context.Context, key string, revision int64) kserver
 		return kserver.WatchResult{CurrentRevision: curRev, CompactRevision: compactRev, Events: eventCh, Errorc: errCh}
 	}
 
+	prefix, _ := translateRange(key, end)
 	go func() {
 		defer close(eventCh)
 		defer close(errCh)
 		// PrevKV is required: toServerEvent classifies an event as Create if
 		// ev.PrevKV == nil. Without it, every update is reported as a Create
 		// and apiserver's watchCache rejects them as duplicate/out-of-order.
-		ch, err := b.node.Watch(ctx, key, revision, t4.WithPrevKV())
+		ch, err := b.node.Watch(ctx, prefix, revision, t4.WithPrevKV())
 		if err != nil {
 			errCh <- translateErr(err)
 			return
@@ -291,4 +294,11 @@ func toServerEvent(ev *t4.Event) *kserver.Event {
 		se.PrevKV = toServerKV(ev.PrevKV, false)
 	}
 	return se
+}
+
+func translateRange(key, end string) (prefix, startKey string) {
+	if end != "" && len(key) > len(end) {
+		return key[:len(end)], key
+	}
+	return key, ""
 }

--- a/pkg/drivers/t4/backend_smoke_test.go
+++ b/pkg/drivers/t4/backend_smoke_test.go
@@ -47,7 +47,7 @@ func TestT4Backend_CreateGetUpdateDelete(t *testing.T) {
 		t.Fatalf("Create duplicate: want ErrKeyExists, got %v", err)
 	}
 
-	_, kv, err := b.Get(ctx, "/a", "", 0, 0, false)
+	_, kv, err := b.Get(ctx, "/a", 0, false)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestT4Backend_CreateGetUpdateDelete(t *testing.T) {
 		t.Fatalf("Update revision %d not greater than %d", rev2, rev)
 	}
 
-	_, kv, err = b.Get(ctx, "/a", "", 0, 0, false)
+	_, kv, err = b.Get(ctx, "/a", 0, false)
 	if err != nil {
 		t.Fatalf("Get after update: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestT4Backend_CreateGetUpdateDelete(t *testing.T) {
 		t.Fatal("Delete returned ok=false")
 	}
 
-	_, kv, err = b.Get(ctx, "/a", "", 0, 0, false)
+	_, kv, err = b.Get(ctx, "/a", 0, false)
 	if err != nil {
 		t.Fatalf("Get after delete: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestT4Backend_ListAndCount(t *testing.T) {
 		}
 	}
 
-	_, kvs, err := b.List(ctx, "/p/", "", 0, 0, false)
+	_, kvs, err := b.List(ctx, "/p/", "/p0", 0, 0, false)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestT4Backend_ListAndCount(t *testing.T) {
 		t.Fatalf("List under /p/ returned %d, want 3", len(kvs))
 	}
 
-	_, count, err := b.Count(ctx, "/p/", "", 0)
+	_, count, err := b.Count(ctx, "/p/", "p0", 0)
 	if err != nil {
 		t.Fatalf("Count: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestT4Backend_ListAndCount(t *testing.T) {
 		t.Fatalf("Count under /p/ = %d, want 3", count)
 	}
 
-	_, kvs, err = b.List(ctx, "/p/", "", 2, 0, false)
+	_, kvs, err = b.List(ctx, "/p/", "/p0", 2, 0, false)
 	if err != nil {
 		t.Fatalf("List limit=2: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestT4Backend_Watch(t *testing.T) {
 		t.Fatalf("CurrentRevision: %v", err)
 	}
 
-	wr := b.Watch(ctx, "/w/", startRev+1)
+	wr := b.Watch(ctx, "/w/", "/w0", startRev+1)
 
 	doneCh := make(chan struct{})
 	gotCreate, gotUpdate, gotDelete := false, false, false
@@ -230,7 +230,7 @@ func TestT4Backend_CompactAndCompactedWatch(t *testing.T) {
 		t.Fatalf("Compact: %v", err)
 	}
 
-	wr := b.Watch(ctx, "/c/", rev1)
+	wr := b.Watch(ctx, "/c/", "/c0", rev1)
 	select {
 	case err := <-wr.Errorc:
 		if !errors.Is(err, kserver.ErrCompacted) {
@@ -253,7 +253,7 @@ func TestT4Backend_FutureRevisionRejected(t *testing.T) {
 		t.Fatalf("CurrentRevision: %v", err)
 	}
 
-	_, _, err = b.Get(ctx, "/f/k", "", 0, cur+100, false)
+	_, _, err = b.Get(ctx, "/f/k", cur+100, false)
 	if !errors.Is(err, kserver.ErrFutureRev) {
 		t.Fatalf("Get future rev: want ErrFutureRev, got %v", err)
 	}

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -3,7 +3,6 @@ package logstructured
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -15,10 +14,10 @@ type Log interface {
 	Start(ctx context.Context) error
 	CompactRevision(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeletes, keysOnly bool) (int64, server.Events, error)
-	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
-	After(ctx context.Context, prefix string, revision, limit int64) (int64, server.Events, error)
-	Watch(ctx context.Context, prefix string) <-chan server.Events
+	List(ctx context.Context, key, end string, limit, revision int64, includeDeletes, keysOnly bool) (int64, server.Events, error)
+	Count(ctx context.Context, key, end string, revision int64) (int64, int64, error)
+	After(ctx context.Context, key, end string, revision, limit int64) (int64, server.Events, error)
+	Watch(ctx context.Context, key, end string) <-chan server.Events
 	Append(ctx context.Context, event *server.Event) (int64, error)
 	DbSize(ctx context.Context) (int64, error)
 	Compact(ctx context.Context, revision int64) (int64, error)
@@ -47,21 +46,21 @@ func (l *LogStructured) Start(ctx context.Context) error {
 	return nil
 }
 
-func (l *LogStructured) Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (revRet int64, kvRet *server.KeyValue, errRet error) {
+func (l *LogStructured) Get(ctx context.Context, key string, revision int64, keysOnly bool) (revRet int64, kvRet *server.KeyValue, errRet error) {
 	defer func() {
 		l.adjustRevision(ctx, &revRet)
 		logrus.Tracef("GET %s, rev=%d => rev=%d, kv=%v, err=%v", key, revision, revRet, kvRet != nil, errRet)
 	}()
 
-	rev, event, err := l.get(ctx, key, rangeEnd, limit, revision, false, keysOnly)
+	rev, event, err := l.get(ctx, key, revision, false, keysOnly)
 	if event == nil {
 		return rev, nil, err
 	}
 	return rev, event.KV, err
 }
 
-func (l *LogStructured) get(ctx context.Context, key, rangeEnd string, limit, revision int64, includeDeletes, keysOnly bool) (int64, *server.Event, error) {
-	rev, events, err := l.log.List(ctx, key, rangeEnd, limit, revision, includeDeletes, keysOnly)
+func (l *LogStructured) get(ctx context.Context, key string, revision int64, includeDeletes, keysOnly bool) (int64, *server.Event, error) {
+	rev, events, err := l.log.List(ctx, key, "", 1, revision, includeDeletes, keysOnly)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -87,7 +86,7 @@ func (l *LogStructured) Create(ctx context.Context, key string, value []byte, le
 		logrus.Tracef("CREATE %s, size=%d, lease=%d => rev=%d, err=%v", key, len(value), lease, revRet, errRet)
 	}()
 
-	_, prevEvent, err := l.get(ctx, key, "", 1, 0, true, true)
+	_, prevEvent, err := l.get(ctx, key, 0, true, true)
 	if err != nil {
 		return 0, err
 	}
@@ -117,7 +116,7 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 		logrus.Tracef("DELETE %s, rev=%d => rev=%d, kv=%v, deleted=%v, err=%v", key, revision, revRet, kvRet != nil, deletedRet, errRet)
 	}()
 
-	rev, event, err := l.get(ctx, key, "", 1, 0, true, false)
+	rev, event, err := l.get(ctx, key, 0, true, false)
 	if err != nil {
 		return 0, nil, false, err
 	}
@@ -143,7 +142,7 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 	if err != nil {
 		// If error on Append we assume it's a UNIQUE constraint error, so we fetch the latest (if we can)
 		// and return that the delete failed
-		latestRev, latestEvent, latestErr := l.get(ctx, key, "", 1, 0, true, false)
+		latestRev, latestEvent, latestErr := l.get(ctx, key, 0, true, false)
 		if latestErr != nil || latestEvent == nil {
 			return rev, event.KV, false, nil
 		}
@@ -152,24 +151,12 @@ func (l *LogStructured) Delete(ctx context.Context, key string, revision int64) 
 	return rev, event.KV, true, err
 }
 
-func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (revRet int64, kvRet []*server.KeyValue, errRet error) {
+func (l *LogStructured) List(ctx context.Context, key, end string, limit, revision int64, keysOnly bool) (revRet int64, kvRet []*server.KeyValue, errRet error) {
 	defer func() {
-		logrus.Tracef("LIST %s, start=%s, limit=%d, rev=%d => rev=%d, kvs=%d, err=%v", prefix, startKey, limit, revision, revRet, len(kvRet), errRet)
+		logrus.Tracef("LIST %s, end=%s, limit=%d, rev=%d => rev=%d, kvs=%d, err=%v", key, end, limit, revision, revRet, len(kvRet), errRet)
 	}()
 
-	// It's assumed that when there is a start key that that key exists.
-	if strings.HasSuffix(prefix, "/") {
-		// In the situation of a list start the startKey will not exist so set to ""
-		if prefix == startKey {
-			startKey = ""
-		}
-		prefix += "%"
-	} else {
-		// Also if this isn't a list there is no reason to pass startKey
-		startKey = ""
-	}
-
-	rev, events, err := l.log.List(ctx, strings.ReplaceAll(prefix, `_`, `^_`), startKey, limit, revision, false, keysOnly)
+	rev, events, err := l.log.List(ctx, key, end, limit, revision, false, keysOnly)
 	kvs := make([]*server.KeyValue, 0, len(events))
 	for _, event := range events {
 		kvs = append(kvs, event.KV)
@@ -177,11 +164,11 @@ func (l *LogStructured) List(ctx context.Context, prefix, startKey string, limit
 	return rev, kvs, err
 }
 
-func (l *LogStructured) Count(ctx context.Context, prefix, startKey string, revision int64) (revRet int64, count int64, err error) {
+func (l *LogStructured) Count(ctx context.Context, key, end string, revision int64) (revRet int64, count int64, err error) {
 	defer func() {
-		logrus.Tracef("COUNT %s, rev=%d => rev=%d, count=%d, err=%v", prefix, revision, revRet, count, err)
+		logrus.Tracef("COUNT %s, end=%s, rev=%d => rev=%d, count=%d, err=%v", key, end, revision, revRet, count, err)
 	}()
-	return l.log.Count(ctx, prefix, startKey, revision)
+	return l.log.Count(ctx, key, end, revision)
 }
 
 func (l *LogStructured) Update(ctx context.Context, key string, value []byte, revision, lease int64) (revRet int64, kvRet *server.KeyValue, updateRet bool, errRet error) {
@@ -194,7 +181,7 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 		logrus.Tracef("UPDATE %s, value=%d, rev=%d, lease=%v => rev=%d, kvrev=%d, updated=%v, err=%v", key, len(value), revision, lease, revRet, kvRev, updateRet, errRet)
 	}()
 
-	rev, event, err := l.get(ctx, key, "", 1, 0, false, false)
+	rev, event, err := l.get(ctx, key, 0, false, false)
 	if err != nil {
 		return 0, nil, false, err
 	}
@@ -219,7 +206,7 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 
 	rev, err = l.log.Append(ctx, updateEvent)
 	if err != nil {
-		rev, event, err := l.get(ctx, key, "", 1, 0, false, false)
+		rev, event, err := l.get(ctx, key, 0, false, false)
 		if event == nil {
 			return rev, nil, false, err
 		}
@@ -230,26 +217,26 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 	return rev, updateEvent.KV, true, err
 }
 
-func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64) server.WatchResult {
-	logrus.Tracef("WATCH %s, revision=%d", prefix, revision)
+func (l *LogStructured) Watch(ctx context.Context, key, end string, revision int64) server.WatchResult {
+	logrus.Tracef("WATCH %s, end=%s, revision=%d", key, end, revision)
 
 	// starting watching right away so we don't miss anything
 	ctx, cancel := context.WithCancel(ctx)
-	readChan := l.log.Watch(ctx, prefix)
-
-	// include the current revision in list
-	if revision > 0 {
-		revision--
-	}
+	readChan := l.log.Watch(ctx, key, end)
 
 	result := make(chan []*server.Event, 100)
 	errc := make(chan error, 1)
 	wr := server.WatchResult{Events: result, Errorc: errc}
 
-	rev, kvs, err := l.log.After(ctx, prefix, revision, 0)
+	// include the current revision in list
+	if revision > 1 {
+		revision--
+	}
+
+	rev, kvs, err := l.log.After(ctx, key, end, revision, 0)
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
-			logrus.Errorf("Failed to list %s for revision %d: %v", prefix, revision, err)
+			logrus.Errorf("Failed to list %s for revision %d: %v", key, revision, err)
 			if err == server.ErrCompacted {
 				compact, _ := l.log.CompactRevision(ctx)
 				wr.CompactRevision = compact
@@ -261,7 +248,7 @@ func (l *LogStructured) Watch(ctx context.Context, prefix string, revision int64
 		cancel()
 	}
 
-	logrus.Tracef("WATCH LIST key=%s rev=%d => rev=%d kvs=%d", prefix, revision, rev, len(kvs))
+	logrus.Tracef("WATCH LIST key=%s rev=%d => rev=%d kvs=%d", key, revision, rev, len(kvs))
 
 	go func() {
 		lastRevision := revision

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -6,14 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/k3s-io/kine/pkg/broadcaster"
 	"github.com/k3s-io/kine/pkg/metrics"
-	"github.com/k3s-io/kine/pkg/query"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/sirupsen/logrus"
 )
@@ -65,7 +63,7 @@ func (s *SQLLog) Start(ctx context.Context) error {
 func (s *SQLLog) compactStart(ctx context.Context) error {
 	logrus.Tracef("COMPACTSTART")
 
-	rows, err := s.d.After(ctx, "compact_rev_key", 0, 0)
+	rows, err := s.d.After(ctx, "compact_rev_key", "", 0, 0)
 	if err != nil {
 		return err
 	}
@@ -313,12 +311,8 @@ func (s *SQLLog) CompactRevision(ctx context.Context) (int64, error) {
 	return s.d.GetCompactRevision(ctx)
 }
 
-func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64) (int64, server.Events, error) {
-	if strings.HasSuffix(prefix, "/") {
-		prefix += "%"
-	}
-
-	rows, err := s.d.After(ctx, prefix, revision, limit)
+func (s *SQLLog) After(ctx context.Context, key, end string, revision, limit int64) (int64, server.Events, error) {
+	rows, err := s.d.After(ctx, key, end, revision, limit)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -344,18 +338,18 @@ func (s *SQLLog) After(ctx context.Context, prefix string, revision, limit int64
 	return rev, result, err
 }
 
-func (s *SQLLog) List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted, keysOnly bool) (int64, server.Events, error) {
+func (s *SQLLog) List(ctx context.Context, key, end string, limit, revision int64, includeDeleted, keysOnly bool) (int64, server.Events, error) {
 	var (
 		rows *sql.Rows
 		err  error
 	)
 
-	startKey = s.d.TranslateStartKey(startKey)
+	key = s.d.TranslateStartKey(key)
 
 	if revision == 0 {
-		rows, err = s.d.ListCurrent(ctx, prefix, startKey, limit, includeDeleted, keysOnly)
+		rows, err = s.d.ListCurrent(ctx, key, end, limit, includeDeleted, keysOnly)
 	} else {
-		rows, err = s.d.List(ctx, prefix, startKey, limit, revision, includeDeleted, keysOnly)
+		rows, err = s.d.List(ctx, key, end, limit, revision, includeDeleted, keysOnly)
 	}
 	if err != nil {
 		return 0, nil, err
@@ -416,19 +410,17 @@ func RowsToEvents(rows *sql.Rows, val, prev bool) (int64, int64, server.Events, 
 	return rev, compact, result, nil
 }
 
-func (s *SQLLog) Watch(ctx context.Context, prefix string) <-chan server.Events {
+func (s *SQLLog) Watch(ctx context.Context, key, end string) <-chan server.Events {
 	res := make(chan server.Events, 100)
 	values, err := s.broadcaster.Subscribe(ctx, s.startWatch)
 	if err != nil {
 		return nil
 	}
 
-	checkPrefix := strings.HasSuffix(prefix, "/")
-
 	go func() {
 		defer close(res)
 		for i := range values {
-			events, ok := filter(i, checkPrefix, prefix)
+			events, ok := filter(i, key, end)
 			if ok {
 				res <- events
 			}
@@ -438,11 +430,10 @@ func (s *SQLLog) Watch(ctx context.Context, prefix string) <-chan server.Events 
 	return res
 }
 
-func filter(eventList server.Events, checkPrefix bool, prefix string) (server.Events, bool) {
+func filter(eventList server.Events, key, end string) (server.Events, bool) {
 	filteredEventList := make(server.Events, 0, len(eventList))
-
 	for _, event := range eventList {
-		if (checkPrefix && strings.HasPrefix(event.KV.Key, prefix)) || event.KV.Key == prefix {
+		if key == "" || (end != "" && event.KV.Key >= key && event.KV.Key < end) || event.KV.Key == key {
 			filteredEventList = append(filteredEventList, event)
 		}
 	}
@@ -478,7 +469,6 @@ func (s *SQLLog) startWatch() (chan server.Events, error) {
 
 func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 	var (
-		stmt         *query.Stmt
 		skip         int64
 		skipTime     time.Time
 		waitForMore  = true
@@ -509,23 +499,10 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		s.polled.Broadcast()
 		s.Unlock()
 
-		if stmt == nil {
-			var err error
-			stmt, err = s.d.PrepareAfter(s.ctx, s.pollBatchSize)
-			if err != nil {
-				logrus.Errorf("Failed to prepare to list latest changes: %v", err)
-			}
-			continue
-		}
-
-		rows, err := s.d.QueryAfter(s.ctx, stmt, "%", pollRevision)
+		rows, err := s.d.After(s.ctx, "", "", pollRevision, s.pollBatchSize)
 		if err != nil {
 			if !errors.Is(err, context.Canceled) {
 				logrus.Errorf("Failed to list latest changes: %v", err)
-			}
-			if stmt != nil {
-				stmt.Close()
-				stmt = nil
 			}
 			continue
 		}
@@ -619,18 +596,14 @@ func canSkipRevision(rev, skip int64, skipTime time.Time) bool {
 	return rev == skip && time.Since(skipTime) > time.Second
 }
 
-func (s *SQLLog) Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error) {
-	if strings.HasSuffix(prefix, "/") {
-		prefix += "%"
-	}
-
-	startKey = s.d.TranslateStartKey(startKey)
+func (s *SQLLog) Count(ctx context.Context, key, end string, revision int64) (int64, int64, error) {
+	key = s.d.TranslateStartKey(key)
 
 	if revision == 0 {
-		return s.d.CountCurrent(ctx, prefix, startKey)
+		return s.d.CountCurrent(ctx, key, end)
 	}
 
-	rev, compact, rows, err := s.d.Count(ctx, prefix, startKey, revision)
+	rev, compact, rows, err := s.d.Count(ctx, key, end, revision)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -664,15 +637,17 @@ func (s *SQLLog) Append(ctx context.Context, event *server.Event) (int64, error)
 	if err != nil {
 		return 0, err
 	}
-	// currentRev may have moved ahead due to other inserts between when Insert returned
-	// and now; ensure that we don't roll it back if it has changed elsewhere. If the
-	// swap succeeded, notify the polling loop of the new revision.
-	if s.currentRev.CompareAndSwap(currentRev, rev) {
-		select {
-		case s.notify <- rev:
-		default:
-		}
+
+	// notify the polling loop of the new revision.
+	select {
+	case s.notify <- rev:
+	default:
 	}
+
+	// currentRev may have moved ahead due to other inserts between when Insert returned
+	// and now; ensure that we don't roll it back if it has changed elsewhere.
+	s.currentRev.CompareAndSwap(currentRev, rev)
+
 	return rev, nil
 }
 

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"database/sql"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -65,19 +64,6 @@ func (f *Filled) String() string {
 
 func (f *Filled) QueryString() string {
 	return fmt.Sprintf(params.ReplaceAllString(f.Query, "%v"), summarize(f.Args)...)
-}
-
-// Stmt is a wrapper around sql.Stmt that remembers what query it was prepared from
-type Stmt struct {
-	*Named
-	Stmt *sql.Stmt
-}
-
-func (s *Stmt) Close() error {
-	if s.Stmt != nil {
-		return s.Stmt.Close()
-	}
-	return nil
 }
 
 func Strip(s string) string {

--- a/pkg/server/compact.go
+++ b/pkg/server/compact.go
@@ -43,7 +43,7 @@ func isCompact(txn *etcdserverpb.TxnRequest) (int64, []byte, bool) {
 // to store the current compact rev to the compact_rev_key. Because kine
 // uses this key internally, we instead operate on a substitute key.
 func (l *LimitedServer) compact(ctx context.Context, compareVersion int64, value []byte) (*etcdserverpb.TxnResponse, error) {
-	rev, kv, err := l.backend.Get(ctx, compactRevAPI, "", 1, 0, false)
+	rev, kv, err := l.backend.Get(ctx, compactRevAPI, 0, false)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (l *LimitedServer) compact(ctx context.Context, compareVersion int64, value
 
 		if err != nil {
 			// create or update failed, get the version from the current value
-			rev, kv, err = l.backend.Get(ctx, compactRevAPI, "", 1, 0, false)
+			rev, kv, err = l.backend.Get(ctx, compactRevAPI, 0, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/get.go
+++ b/pkg/server/get.go
@@ -2,15 +2,14 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
 func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (*RangeResponse, error) {
-	if r.Limit != 0 && len(r.RangeEnd) != 0 {
-		return nil, fmt.Errorf("invalid combination of rangeEnd and limit, limit should be 0 got %d", r.Limit)
+	if r.Limit > 1 {
+		return nil, unsupported("limit")
 	}
 
 	key := string(r.Key)
@@ -20,8 +19,8 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		key = compactRevAPI
 	}
 
-	rev, kv, err := l.backend.Get(ctx, key, string(r.RangeEnd), r.Limit, r.Revision, r.KeysOnly)
-	logrus.Tracef("GET key=%s, end=%s, revision=%d, currentRev=%d, limit=%d, keysOnly=%v", r.Key, r.RangeEnd, r.Revision, rev, r.Limit, r.KeysOnly)
+	rev, kv, err := l.backend.Get(ctx, key, r.Revision, r.KeysOnly)
+	logrus.Tracef("GET key=%s, revision=%d, currentRev=%d, keysOnly=%v", key, r.Revision, rev, r.KeysOnly)
 	resp := &RangeResponse{
 		Header: txnHeader(rev),
 	}

--- a/pkg/server/list.go
+++ b/pkg/server/list.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -14,23 +13,20 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		return nil, errors.New("invalid range end length of 0")
 	}
 
-	prefix := string(append(r.RangeEnd[:len(r.RangeEnd)-1], r.RangeEnd[len(r.RangeEnd)-1]-1))
-	if !strings.HasSuffix(prefix, "/") {
-		prefix = prefix + "/"
-	}
-	start := string(r.Key)
+	key := string(r.Key)
+	end := string(r.RangeEnd)
 	revision := int64(0)
 	if r.Revision > 0 {
 		revision = r.Revision
 	}
 
 	if r.CountOnly {
-		rev, count, err := l.backend.Count(ctx, prefix, start, revision)
+		rev, count, err := l.backend.Count(ctx, key, end, revision)
 		resp := &RangeResponse{
 			Header: txnHeader(rev),
 			Count:  count,
 		}
-		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", r.Key, r.RangeEnd, revision, rev, count)
+		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", key, end, revision, rev, count)
 		return resp, err
 	}
 
@@ -39,8 +35,8 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 		limit++
 	}
 
-	rev, kvs, err := l.backend.List(ctx, prefix, start, limit, revision, r.KeysOnly)
-	logrus.Tracef("LIST key=%s, end=%s, revision=%d, currentRev=%d count=%d, limit=%d, keysOnly=%v", r.Key, r.RangeEnd, revision, rev, len(kvs), r.Limit, r.KeysOnly)
+	rev, kvs, err := l.backend.List(ctx, key, end, limit, revision, r.KeysOnly)
+	logrus.Tracef("LIST key=%s, end=%s, revision=%d, currentRev=%d count=%d, limit=%d, keysOnly=%v", key, end, revision, rev, len(kvs), r.Limit, r.KeysOnly)
 	resp := &RangeResponse{
 		Header: txnHeader(rev),
 		Count:  int64(len(kvs)),
@@ -56,8 +52,8 @@ func (l *LimitedServer) list(ctx context.Context, r *etcdserverpb.RangeRequest) 
 			revision = rev
 		}
 
-		rev, resp.Count, err = l.backend.Count(ctx, prefix, start, revision)
-		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", r.Key, r.RangeEnd, revision, rev, resp.Count)
+		rev, resp.Count, err = l.backend.Count(ctx, key, end, revision)
+		logrus.Tracef("LIST COUNT key=%s, end=%s, revision=%d, currentRev=%d count=%d", key, end, revision, rev, resp.Count)
 		resp.Header = txnHeader(rev)
 	}
 

--- a/pkg/server/put.go
+++ b/pkg/server/put.go
@@ -24,7 +24,7 @@ func (l *LimitedServer) Put(ctx context.Context, r *etcdserverpb.PutRequest) (*e
 
 	rev, err := l.backend.Create(ctx, key, r.Value, r.Lease)
 	if err == ErrKeyExists {
-		rev, kv, err = l.backend.Get(ctx, key, "", 1, rev, false)
+		rev, kv, err = l.backend.Get(ctx, key, rev, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/k3s-io/kine/pkg/query"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,13 +27,13 @@ const (
 
 type Backend interface {
 	Start(ctx context.Context) error
-	Get(ctx context.Context, key, rangeEnd string, limit, revision int64, keysOnly bool) (int64, *KeyValue, error)
+	Get(ctx context.Context, key string, revision int64, keysOnly bool) (int64, *KeyValue, error)
 	Create(ctx context.Context, key string, value []byte, lease int64) (int64, error)
 	Delete(ctx context.Context, key string, revision int64) (int64, *KeyValue, bool, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64, keysOnly bool) (int64, []*KeyValue, error)
-	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, error)
+	List(ctx context.Context, key, end string, limit, revision int64, keysOnly bool) (int64, []*KeyValue, error)
+	Count(ctx context.Context, key, end string, revision int64) (int64, int64, error)
 	Update(ctx context.Context, key string, value []byte, revision, lease int64) (int64, *KeyValue, bool, error)
-	Watch(ctx context.Context, key string, revision int64) WatchResult
+	Watch(ctx context.Context, key, end string, revision int64) WatchResult
 	DbSize(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	Compact(ctx context.Context, revision int64) (int64, error)
@@ -42,14 +41,12 @@ type Backend interface {
 }
 
 type Dialect interface {
-	ListCurrent(ctx context.Context, prefix, startKey string, limit int64, includeDeleted, keysOnly bool) (*sql.Rows, error)
-	List(ctx context.Context, prefix, startKey string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error)
-	CountCurrent(ctx context.Context, prefix, startKey string) (int64, int64, error)
-	Count(ctx context.Context, prefix, startKey string, revision int64) (int64, int64, int64, error)
+	ListCurrent(ctx context.Context, key, end string, limit int64, includeDeleted, keysOnly bool) (*sql.Rows, error)
+	List(ctx context.Context, key, end string, limit, revision int64, includeDeleted, keysOnly bool) (*sql.Rows, error)
+	CountCurrent(ctx context.Context, key, end string) (int64, int64, error)
+	Count(ctx context.Context, key, end string, revision int64) (int64, int64, int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
-	After(ctx context.Context, prefix string, rev, limit int64) (*sql.Rows, error)
-	PrepareAfter(ctx context.Context, limit int64) (*query.Stmt, error)
-	QueryAfter(ctx context.Context, stmt *query.Stmt, prefix string, rev int64) (*sql.Rows, error)
+	After(ctx context.Context, key, end string, rev, limit int64) (*sql.Rows, error)
 	//nolint:revive
 	Insert(ctx context.Context, key string, create, delete bool, createRevision, previousRevision int64, ttl int64, value []byte) (int64, error)
 	DeleteRevision(ctx context.Context, revision int64) error

--- a/pkg/server/update.go
+++ b/pkg/server/update.go
@@ -33,7 +33,7 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 	if rev == 0 {
 		rev, err = l.backend.Create(ctx, key, value, lease)
 		if err == ErrKeyExists {
-			rev, kv, err = l.backend.Get(ctx, key, "", 1, rev, false)
+			rev, kv, err = l.backend.Get(ctx, key, rev, false)
 		} else {
 			ok = true
 		}

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -133,6 +133,7 @@ func (w *watcher) Create(ctx context.Context, r *etcdserverpb.WatchCreateRequest
 	w.watches[id] = cancel
 
 	key := string(r.Key)
+	end := string(r.RangeEnd)
 	startRevision := r.StartRevision
 
 	// redirect apiserver watches to the substitute compact revision key
@@ -147,13 +148,13 @@ func (w *watcher) Create(ctx context.Context, r *etcdserverpb.WatchCreateRequest
 		w.progress[id] = progressCh
 	}
 
-	logrus.Tracef("WATCH CREATE server=%d, id=%d, key=%s, revision=%d, progressNotify=%v, watchCount=%d", w.id, id, key, startRevision, r.ProgressNotify, len(w.watches))
+	logrus.Tracef("WATCH CREATE server=%d, id=%d, key=%s, end=%s revision=%d, progressNotify=%v, watchCount=%d", w.id, id, key, end, startRevision, r.ProgressNotify, len(w.watches))
 
 	w.wg.Add(1)
-	go w.watch(ctx, key, id, startRevision, progressCh)
+	go w.watch(ctx, key, end, id, startRevision, progressCh)
 }
 
-func (w *watcher) watch(ctx context.Context, key string, id, startRevision int64, progressCh chan int64) {
+func (w *watcher) watch(ctx context.Context, key, end string, id, startRevision int64, progressCh chan int64) {
 	defer w.wg.Done()
 	trace := logrus.IsLevelEnabled(logrus.TraceLevel)
 
@@ -166,7 +167,7 @@ func (w *watcher) watch(ctx context.Context, key string, id, startRevision int64
 		return
 	}
 
-	wr := w.backend.Watch(ctx, key, startRevision)
+	wr := w.backend.Watch(ctx, key, end, startRevision)
 
 	// If the watch result has a non-zero CompactRevision, then the watch request failed due to
 	// the requested start revision having been compacted.  Pass the current and and compact

--- a/pkg/testserver/test_server.go
+++ b/pkg/testserver/test_server.go
@@ -42,6 +42,10 @@ func NewTestConfig(t testing.TB) *embed.Config {
 func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
 	t.Helper()
 	logrus.SetLevel(logrus.TraceLevel)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339Nano,
+	})
 	logrus.SetOutput(t.Output())
 
 	if cfg == nil {

--- a/pkg/ttl/ttl.go
+++ b/pkg/ttl/ttl.go
@@ -61,7 +61,7 @@ func Run(ctx context.Context, b server.Backend) {
 
 	// Watch from rev+1: seed already covered everything up to rev, so we
 	// only need events strictly after.
-	wr := b.Watch(ctx, "/", rev+1)
+	wr := b.Watch(ctx, "", "", rev+1)
 	if wr.CompactRevision != 0 {
 		logrus.Errorf("TTL event watch failed: %v", server.ErrCompacted)
 		queue.ShutDown()
@@ -98,7 +98,7 @@ func Run(ctx context.Context, b server.Backend) {
 // to the workqueue. Pagination is anchored at the revision returned by the
 // first List so subsequent pages are stable.
 func seed(ctx context.Context, b server.Backend, mu *sync.RWMutex, queue workqueue.TypedDelayingInterface[string], store map[string]*entry) (int64, error) {
-	rev, kvs, err := b.List(ctx, "/", "/", listPageSize, 0, true)
+	rev, kvs, err := b.List(ctx, "/", "0", listPageSize, 0, true)
 	if err != nil {
 		return rev, err
 	}
@@ -113,7 +113,7 @@ func seed(ctx context.Context, b server.Backend, mu *sync.RWMutex, queue workque
 		if int64(len(kvs)) < listPageSize {
 			break
 		}
-		_, kvs, err = b.List(ctx, "/", kvs[len(kvs)-1].Key, listPageSize, rev, true)
+		_, kvs, err = b.List(ctx, kvs[len(kvs)-1].Key, "0", listPageSize, rev, true)
 		if err != nil {
 			return rev, err
 		}

--- a/scripts/test-helpers
+++ b/scripts/test-helpers
@@ -237,7 +237,7 @@ build-apiserver-tests() {
   # fix test that expects only 1 revision to exist at startup - kine has 2, as we store compact revision in a key.
   sed -i 's|NewTooLargeResourceVersionError(uint64(102), 1, 0)|NewTooLargeResourceVersionError(uint64(102), 2, 0)|' pkg/storage/etcd3/watcher_test.go
   # fix too-short test helper timeout that fails under load
-  sed -i 's|waitTimeout = 100 * waitDelay|waitTimeout = 500 * waitDelay|' pkg/storage/etcd3/compact_test.go
+  sed -i 's|waitTimeout = 100 \* waitDelay|waitTimeout = 500 \* waitDelay|' pkg/storage/etcd3/compact_test.go
   go mod edit --replace github.com/k3s-io/kine=$KINEPATH
   go mod tidy
   go test -c -o $KINEPATH/bin/ -tags nats ./pkg/storage/etcd3/...


### PR DESCRIPTION
We historically did a lot of work to convert range start/end options to
a prefix to enable use of the sql LIKE clause. However, LIKE does not
consistently make good use of indexes, and has issues with case folding
on some engines.

Use of GTE/LT allows all SQL engines to better make use of the name
index when listing keys within a range. If we use GTE/LT and the
client-provided range start/end, we can drop a bunch of the translations
we have been doing to strip suffixes and replace characters that have
special meaning within a LIKE expression, and just pass the values
through directly.

For drivers that use a btree internally (memory/nats/t4), this change also
allows us to stop unwrapping the prefix/startKey translation, and just
directly range within the btree index.

#### Linked Issue:
* https://github.com/k3s-io/kine/issues/690

#### Notes

sqlite3 query plan shows that it is now searching the index within a range:
```
QUERY PLAN
|--CO-ROUTINE current
|  `--SEARCH kine USING COVERING INDEX kine_id_deleted_index
|--MATERIALIZE compact
|  `--SEARCH kine USING COVERING INDEX kine_name_prev_revision_uindex (name=?)
|--MATERIALIZE mkv
|  `--SEARCH kine USING COVERING INDEX kine_name_index (name>? AND name<?)  <<< SEARCH index
|--SCAN current
|--SCAN compact
|--SCAN mkv
|--SEARCH kine USING INTEGER PRIMARY KEY (rowid=?)
`--USE TEMP B-TREE FOR ORDER BY
```

previously, it was scanning the whole index:
```
QUERY PLAN
|--CO-ROUTINE current
|  `--SEARCH kine USING COVERING INDEX kine_id_deleted_index
|--MATERIALIZE compact
|  `--SEARCH kine USING COVERING INDEX kine_name_prev_revision_uindex (name=?)
|--MATERIALIZE mkv
|  `--SCAN kine USING COVERING INDEX kine_name_index  <<< SCAN index
|--SCAN current
|--SCAN compact
|--SCAN mkv
|--SEARCH kine USING INTEGER PRIMARY KEY (rowid=?)
`--USE TEMP B-TREE FOR ORDER BY
```

On other engines where the column collation assisted with converting the LIKE to an index search, this at least removes a bunch of logic for prefix detection and escaping of the LIKE query value.

