### PR TITLE
Enable sqlite internal statement cache

### DIFF
--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	DefaultParams = "_journal_mode=WAL&_busy_timeout=30000&_synchronous=NORMAL&_txlock=immediate&cache=shared"
+	DefaultParams = "_journal_mode=WAL&_busy_timeout=30000&_synchronous=NORMAL&_txlock=immediate&_stmt_cache_size=20&cache=shared"
 	DefaultDSN    = "./db/state.db?" + DefaultParams
 
 	schema = []string{


### PR DESCRIPTION
x-ref: https://github.com/mattn/go-sqlite3/pull/1387

> This change adds an opt-in connection-local statement cache to go-sqlite3, enabled via the DSN parameter _stmt_cache_size=N.
> 
> The motivation is that, in this benchmark, the main gap in mattn/go-sqlite3 was not cgo alone but repeated prepare/finalize on hot QueryRow paths. Reusing prepared statements at the driver level closes most of that gap without requiring application code to switch to explicit db.Prepare(...).