### PR TITLE
Optimize nats replay decoding

### DIFF
--- a/pkg/drivers/nats/codec.go
+++ b/pkg/drivers/nats/codec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/klauspost/compress/s2"
 	"github.com/nats-io/nats.go/jetstream"
@@ -11,10 +12,18 @@ import (
 )
 
 const (
-	noRootPrefix = "meta"
+	noRootPrefix              = "meta"
+	valueDecoderAllocBlock    = 1024
+	valueDecoderPoolMaxRetain = 65_536
 )
 
 var keyAlphabet = base58.BitcoinAlphabet
+
+var valueDecoderPool = sync.Pool{
+	New: func() any {
+		return s2.NewReader(nil, s2.ReaderAllocBlock(valueDecoderAllocBlock))
+	},
+}
 
 // keyCodec turns keys like /this/is/a.test.key into Base58 encoded values
 // split on `.` This is because NATS keys are split on . rather than /.
@@ -124,7 +133,21 @@ func (*valueCodec) Encode(src []byte, dst io.Writer) error {
 }
 
 func (*valueCodec) Decode(src io.Reader, dst io.Writer) error {
-	dec := s2.NewReader(src)
-	_, err := io.Copy(dst, dec)
+	pooled := valueDecoderPool.Get()
+	dec, ok := pooled.(*s2.Reader)
+	if !ok {
+		return fmt.Errorf("unexpected value decoder type %T", pooled)
+	}
+	dec.Reset(src)
+
+	written, err := io.Copy(dst, dec)
+
+	dec.Reset(nil)
+	if err == nil &&
+		written <= valueDecoderPoolMaxRetain &&
+		dec.GetBufferCapacity() <= valueDecoderPoolMaxRetain {
+		valueDecoderPool.Put(dec)
+	}
+
 	return err
 }

--- a/pkg/drivers/nats/codec.go
+++ b/pkg/drivers/nats/codec.go
@@ -14,7 +14,7 @@ import (
 const (
 	noRootPrefix              = "meta"
 	valueDecoderAllocBlock    = 1024
-	valueDecoderPoolMaxRetain = 65_536
+	valueDecoderPoolMaxRetain = 65536
 )
 
 var keyAlphabet = base58.BitcoinAlphabet

--- a/pkg/drivers/nats/codec_test.go
+++ b/pkg/drivers/nats/codec_test.go
@@ -100,7 +100,7 @@ func TestKeyEncodeRange(t *testing.T) {
 }
 
 func TestValueCodecRoundTrip(t *testing.T) {
-	for _, size := range []int{0, 1, 1_024, 4_096, 65_536, 1_048_577} {
+	for _, size := range []int{0, 1, 1024, 4096, 65536, 1048577} {
 		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
 			value := testValue(size)
 
@@ -122,7 +122,7 @@ func TestValueCodecRoundTrip(t *testing.T) {
 }
 
 func TestValueCodecConcurrentDecode(t *testing.T) {
-	value := testValue(4_096)
+	value := testValue(4096)
 
 	var encoded bytes.Buffer
 	if err := (&valueCodec{}).Encode(value, &encoded); err != nil {
@@ -165,7 +165,7 @@ func TestValueCodecConcurrentDecode(t *testing.T) {
 }
 
 func BenchmarkValueCodecDecode(b *testing.B) {
-	for _, size := range []int{4_096, 65_536} {
+	for _, size := range []int{4096, 65536} {
 		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
 			value := testValue(size)
 			var encoded bytes.Buffer

--- a/pkg/drivers/nats/codec_test.go
+++ b/pkg/drivers/nats/codec_test.go
@@ -1,7 +1,10 @@
 package nats
 
 import (
+	"bytes"
 	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 )
 
@@ -94,4 +97,100 @@ func TestKeyEncodeRange(t *testing.T) {
 			t.Errorf("Expected %q for %q, got %q", test.Out, test.In, out)
 		}
 	}
+}
+
+func TestValueCodecRoundTrip(t *testing.T) {
+	for _, size := range []int{0, 1, 1_024, 4_096, 65_536, 1_048_577} {
+		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+			value := testValue(size)
+
+			var encoded bytes.Buffer
+			if err := (&valueCodec{}).Encode(value, &encoded); err != nil {
+				t.Fatal(err)
+			}
+
+			var decoded bytes.Buffer
+			if err := (&valueCodec{}).Decode(bytes.NewReader(encoded.Bytes()), &decoded); err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(value, decoded.Bytes()) {
+				t.Fatalf("decoded value does not match input: got %d bytes, want %d", decoded.Len(), len(value))
+			}
+		})
+	}
+}
+
+func TestValueCodecConcurrentDecode(t *testing.T) {
+	value := testValue(4_096)
+
+	var encoded bytes.Buffer
+	if err := (&valueCodec{}).Encode(value, &encoded); err != nil {
+		t.Fatal(err)
+	}
+	compressed := encoded.Bytes()
+
+	const (
+		workers    = 16
+		iterations = 100
+	)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	codec := &valueCodec{}
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				var decoded bytes.Buffer
+				if err := codec.Decode(bytes.NewReader(compressed), &decoded); err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(value, decoded.Bytes()) {
+					errs <- fmt.Errorf("decoded value does not match input: got %d bytes, want %d", decoded.Len(), len(value))
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func BenchmarkValueCodecDecode(b *testing.B) {
+	for _, size := range []int{4_096, 65_536} {
+		b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+			value := testValue(size)
+			var encoded bytes.Buffer
+			if err := (&valueCodec{}).Encode(value, &encoded); err != nil {
+				b.Fatal(err)
+			}
+			compressed := encoded.Bytes()
+			codec := &valueCodec{}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+
+			for range b.N {
+				var decoded bytes.Buffer
+				if err := codec.Decode(bytes.NewReader(compressed), &decoded); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func testValue(size int) []byte {
+	value := make([]byte, size)
+	_, _ = rand.New(rand.NewSource(int64(size))).Read(value)
+	return value
 }


### PR DESCRIPTION
For #720, based on a scale testing benchmark, a core bottleneck was S2 reader allocations. This change reducing the default allocation size of the reader itself, but also introduces a sync.Pool to reuse existing buffers.