### PR TITLE
Fix delayed watch progress notifications

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -309,14 +309,15 @@ func run(c *cli.Context) (rerr error) {
 		return fmt.Errorf("invalid log format: %s", config.LogFormat)
 	}
 
-	if c.Bool("debug") {
-		logrus.SetLevel(logrus.TraceLevel)
-	}
-
-	// send info/error/warning to stderr, debug/trace to stdout
+	// send info/error/warning to stderr
 	logrus.SetOutput(ioutil.Discard)
 	logrus.AddHook(&writer.Hook{Writer: os.Stderr, LogLevels: []logrus.Level{logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel, logrus.WarnLevel, logrus.InfoLevel}})
-	logrus.AddHook(&writer.Hook{Writer: os.Stdout, LogLevels: []logrus.Level{logrus.DebugLevel, logrus.TraceLevel}})
+
+	if c.Bool("debug") {
+		// send debug/trace to stdout
+		logrus.SetLevel(logrus.TraceLevel)
+		logrus.AddHook(&writer.Hook{Writer: os.Stdout, LogLevels: []logrus.Level{logrus.DebugLevel, logrus.TraceLevel}})
+	}
 
 	ctx := signals.SetupSignalContext()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -308,7 +308,8 @@ func (l *loggingServerStream) SendMsg(m any) error {
 	start := time.Now()
 	defer func() {
 		if wr, ok := m.(*etcdserverpb.WatchResponse); ok {
-			logrus.Tracef("STREAM STATS WATCH SEND DONE client=%s, id=%d, revision=%d, events=%d, size=%d, reason=%q, time=%s", l.clientAddr, wr.WatchId, wr.Header.Revision, len(wr.Events), wr.Size(), wr.CancelReason, time.Since(start).Truncate(time.Microsecond))
+			logrus.Tracef("STREAM STATS WATCH SEND DONE client=%s, id=%d, revision=%d, events=%d, size=%d, created=%v, canceled=%v, reason=%q, time=%s",
+				l.clientAddr, wr.WatchId, wr.Header.Revision, len(wr.Events), wr.Size(), wr.Created, wr.Canceled, wr.CancelReason, time.Since(start).Truncate(time.Microsecond))
 			return
 		}
 		if p, ok := m.(proto.Message); ok {

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -178,7 +178,9 @@ func (l *LogStructured) Update(ctx context.Context, key string, value []byte, re
 		if kvRet != nil {
 			kvRev = kvRet.ModRevision
 		}
-		logrus.Tracef("UPDATE %s, value=%d, rev=%d, lease=%v => rev=%d, kvrev=%d, updated=%v, err=%v", key, len(value), revision, lease, revRet, kvRev, updateRet, errRet)
+		if logrus.IsLevelEnabled(logrus.TraceLevel) {
+			logrus.Tracef("UPDATE %s, value=%d, rev=%d, lease=%v => rev=%d, kvrev=%d, updated=%v, err=%v", key, len(value), revision, lease, revRet, kvRev, updateRet, errRet)
+		}
 	}()
 
 	rev, event, err := l.get(ctx, key, 0, false, false)

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -488,6 +488,12 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 	defer close(result)
 
 	for {
+		// broadcast polled revision to reflect what rows have already been sent to event channel
+		s.Lock()
+		s.polledRev.Store(pollRevision)
+		s.polled.Broadcast()
+		s.Unlock()
+
 		if waitForMore {
 			select {
 			case <-s.ctx.Done():
@@ -499,13 +505,6 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			case <-wait.C:
 			}
 		}
-		waitForMore = true
-
-		//  update polled revision to reflect what rows have already been seen
-		s.Lock()
-		s.polledRev.Store(pollRevision)
-		s.polled.Broadcast()
-		s.Unlock()
 
 		rows, err := s.d.After(s.ctx, "", "", pollRevision, s.pollBatchSize)
 		if err != nil {
@@ -516,6 +515,7 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		}
 
 		_, _, events, err := RowsToEvents(rows, true, true)
+		waitForMore = len(events) < 100
 		if err != nil {
 			logrus.Errorf("fail to convert rows changes: %v", err)
 			continue
@@ -528,8 +528,6 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		if len(events) == 0 {
 			continue
 		}
-
-		waitForMore = len(events) < 100
 
 		var (
 			rev        = pollRevision

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -400,8 +400,8 @@ func RowsToEvents(rows *sql.Rows, val, prev bool) (int64, int64, server.Events, 
 	defer rows.Close()
 
 	for rows.Next() {
-		event := &server.Event{}
-		if err := scan(rows, &rev, &compact, event, val, prev); err != nil {
+		event, err := scan(rows, &rev, &compact, val, prev)
+		if err != nil {
 			return 0, 0, nil, err
 		}
 		result = append(result, event)
@@ -420,8 +420,7 @@ func (s *SQLLog) Watch(ctx context.Context, key, end string) <-chan server.Event
 	go func() {
 		defer close(res)
 		for i := range values {
-			events, ok := filter(i, key, end)
-			if ok {
+			if events, ok := filter(i, key, end); ok {
 				res <- events
 			}
 		}
@@ -430,15 +429,23 @@ func (s *SQLLog) Watch(ctx context.Context, key, end string) <-chan server.Event
 	return res
 }
 
-func filter(eventList server.Events, key, end string) (server.Events, bool) {
-	filteredEventList := make(server.Events, 0, len(eventList))
-	for _, event := range eventList {
-		if key == "" || (end != "" && event.KV.Key >= key && event.KV.Key < end) || event.KV.Key == key {
-			filteredEventList = append(filteredEventList, event)
+func filter(events server.Events, key, end string) (server.Events, bool) {
+	// optimization: do not allocate a new Events slice to filter into if there is only a single entry
+	if len(events) == 1 {
+		if events[0].InRange(key, end) {
+			return events, true
+		}
+		return nil, false
+	}
+
+	filteredEvents := make(server.Events, 0, len(events))
+	for _, event := range events {
+		if event.InRange(key, end) {
+			filteredEvents = append(filteredEvents, event)
 		}
 	}
 
-	return filteredEventList, len(filteredEventList) > 0
+	return filteredEvents, len(filteredEvents) > 0
 }
 
 func (s *SQLLog) startWatch() (chan server.Events, error) {
@@ -473,6 +480,7 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		skipTime     time.Time
 		waitForMore  = true
 		pollRevision = pollStart
+		trace        = logrus.IsLevelEnabled(logrus.TraceLevel)
 	)
 
 	wait := time.NewTicker(time.Second)
@@ -513,7 +521,9 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			continue
 		}
 
-		logrus.Tracef("POLL AFTER %d, limit=%d, events=%d", pollRevision, s.pollBatchSize, len(events))
+		if trace {
+			logrus.Tracef("POLL AFTER %d, limit=%d, events=%d", pollRevision, s.pollBatchSize, len(events))
+		}
 
 		if len(events) == 0 {
 			continue
@@ -521,18 +531,20 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 
 		waitForMore = len(events) < 100
 
-		rev := pollRevision
 		var (
-			sequential server.Events
-			saveLast   bool
+			rev        = pollRevision
+			saveLast   = false
+			sequential = make(server.Events, len(events))
 		)
 
-		for _, event := range events {
+		for i, event := range events {
 			next := rev + 1
 			// Ensure that we are notifying events in a sequential fashion. For example if we find row 4 before 3
 			// we don't want to notify row 4 because 3 is essentially dropped forever.
 			if event.KV.ModRevision != next {
-				logrus.Tracef("MODREVISION GAP: expected %v, got %v", next, event.KV.ModRevision)
+				if trace {
+					logrus.Tracef("MODREVISION GAP: expected %v, got %v", next, event.KV.ModRevision)
+				}
 				if canSkipRevision(next, skip, skipTime) {
 					// This situation should never happen, but we have it here as a fallback just for unknown reasons
 					// we don't want to pause all watches forever
@@ -555,13 +567,17 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 					break
 				} else {
 					if err := s.d.Fill(s.ctx, next); err == nil {
-						logrus.Tracef("FILL, revision=%d, err=%v", next, err)
+						if trace {
+							logrus.Tracef("FILL, revision=%d, err=%v", next, err)
+						}
 						select {
 						case s.notify <- next:
 						default:
 						}
 					} else {
-						logrus.Tracef("FILL FAILED, revision=%d, err=%v", next, err)
+						if trace {
+							logrus.Tracef("FILL FAILED, revision=%d, err=%v", next, err)
+						}
 					}
 					break
 				}
@@ -575,19 +591,21 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			saveLast = true
 			rev = event.KV.ModRevision
 			if s.d.IsFill(event.KV.Key) {
-				logrus.Tracef("NOT TRIGGER FILL %s, revision=%d, delete=%v", event.KV.Key, event.KV.ModRevision, event.Delete)
+				if trace {
+					logrus.Tracef("BROADCAST SKIPPED FOR FILL %s, revision=%d, delete=%v", event.KV.Key, event.KV.ModRevision, event.Delete)
+				}
 			} else {
-				sequential = append(sequential, event)
-				logrus.Tracef("TRIGGERED %s, revision=%d, delete=%v", event.KV.Key, event.KV.ModRevision, event.Delete)
+				sequential[i] = event
+				if trace {
+					logrus.Tracef("BROADCAST %s, revision=%d, delete=%v", event.KV.Key, event.KV.ModRevision, event.Delete)
+				}
 			}
 		}
 
 		if saveLast {
 			s.currentRev.CompareAndSwap(pollRevision, rev)
 			pollRevision = rev
-			if len(sequential) > 0 {
-				result <- sequential
-			}
+			result <- sequential
 		}
 	}
 }
@@ -651,33 +669,43 @@ func (s *SQLLog) Append(ctx context.Context, event *server.Event) (int64, error)
 	return rev, nil
 }
 
-func scan(rows *sql.Rows, rev *int64, compact *int64, event *server.Event, val, prev bool) error {
-	event.KV = &server.KeyValue{}
-	event.PrevKV = &server.KeyValue{}
-
-	c := &sql.NullInt64{}
-	dests := []any{
-		rev,
-		c,
-		&event.KV.ModRevision,
-		&event.KV.Key,
-		&event.Create,
-		&event.Delete,
-		&event.KV.CreateRevision,
-		&event.PrevKV.ModRevision,
-		&event.KV.Lease,
+// scan scans the current row's columns into a server.Event struct.
+// If a valid event is scanned, the passed rev and compact vars are also updated.
+func scan(rows *sql.Rows, rev *int64, compact *int64, val, prev bool) (*server.Event, error) {
+	event := &server.Event{
+		KV:     &server.KeyValue{},
+		PrevKV: &server.KeyValue{},
+	}
+	currentRev := &sql.NullInt64{}
+	compactRev := &sql.NullInt64{}
+	colCount := 9
+	if val {
+		colCount++
+		if prev {
+			colCount++
+		}
 	}
 
+	dests := make([]any, colCount)
+	dests[0] = currentRev
+	dests[1] = compactRev
+	dests[2] = &event.KV.ModRevision
+	dests[3] = &event.KV.Key
+	dests[4] = &event.Create
+	dests[5] = &event.Delete
+	dests[6] = &event.KV.CreateRevision
+	dests[7] = &event.PrevKV.ModRevision
+	dests[8] = &event.KV.Lease
 	if val {
-		dests = append(dests, &event.KV.Value)
+		dests[9] = &event.KV.Value
 		if prev {
-			dests = append(dests, &event.PrevKV.Value)
+			dests[10] = &event.PrevKV.Value
 		}
 	}
 
 	err := rows.Scan(dests...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if event.Create {
@@ -689,8 +717,9 @@ func scan(rows *sql.Rows, rev *int64, compact *int64, event *server.Event, val, 
 		event.PrevKV.Key = event.KV.Key
 	}
 
-	*compact = c.Int64
-	return nil
+	*rev = currentRev.Int64
+	*compact = compactRev.Int64
+	return event, nil
 }
 
 // safeCompactRev ensures that we never compact the most recent 1000 revisions.

--- a/pkg/server/compact.go
+++ b/pkg/server/compact.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	compactRevKey = "compact_rev_key"           // key used by apiserver to track compaction, and also used internally by kine for the same purpose
-	compactRevAPI = "compact_rev_key_apiserver" // key used by kine to store the apiserver's compact_rev_key value
+	compactRevKey = []byte("compact_rev_key")           // key used by apiserver to track compaction, and also used internally by kine for the same purpose
+	compactRevAPI = []byte("compact_rev_key_apiserver") // key used by kine to store the apiserver's compact_rev_key value
 )
 
 func (l *LimitedServer) Compact(ctx context.Context, r *etcdserverpb.CompactionRequest) (*etcdserverpb.CompactionResponse, error) {
@@ -33,7 +33,7 @@ func isCompact(txn *etcdserverpb.TxnRequest) (int64, []byte, bool) {
 		txn.Success[0].GetRequestPut() != nil &&
 		len(txn.Failure) == 1 &&
 		txn.Failure[0].GetRequestRange() != nil &&
-		string(txn.Compare[0].Key) == compactRevKey {
+		bytes.Equal(txn.Compare[0].Key, compactRevKey) {
 		return txn.Compare[0].GetVersion(), txn.Success[0].GetRequestPut().Value, true
 	}
 	return 0, nil, false
@@ -43,7 +43,7 @@ func isCompact(txn *etcdserverpb.TxnRequest) (int64, []byte, bool) {
 // to store the current compact rev to the compact_rev_key. Because kine
 // uses this key internally, we instead operate on a substitute key.
 func (l *LimitedServer) compact(ctx context.Context, compareVersion int64, value []byte) (*etcdserverpb.TxnResponse, error) {
-	rev, kv, err := l.backend.Get(ctx, compactRevAPI, 0, false)
+	rev, kv, err := l.backend.Get(ctx, string(compactRevAPI), 0, false)
 	if err != nil {
 		return nil, err
 	}
@@ -62,14 +62,14 @@ func (l *LimitedServer) compact(ctx context.Context, compareVersion int64, value
 	if compareVersion == version {
 		value := EncodeVersion(version+1, value)
 		if version == 0 {
-			rev, err = l.backend.Create(ctx, compactRevAPI, value, 0)
+			rev, err = l.backend.Create(ctx, string(compactRevAPI), value, 0)
 		} else {
-			rev, _, _, err = l.backend.Update(ctx, compactRevAPI, value, modRev, 0)
+			rev, _, _, err = l.backend.Update(ctx, string(compactRevAPI), value, modRev, 0)
 		}
 
 		if err != nil {
 			// create or update failed, get the version from the current value
-			rev, kv, err = l.backend.Get(ctx, compactRevAPI, 0, false)
+			rev, kv, err = l.backend.Get(ctx, string(compactRevAPI), 0, false)
 			if err != nil {
 				return nil, err
 			}
@@ -100,7 +100,7 @@ func (l *LimitedServer) compact(ctx context.Context, compareVersion int64, value
 						Header: &etcdserverpb.ResponseHeader{},
 						Kvs: []*mvccpb.KeyValue{
 							{
-								Key:     []byte(compactRevKey),
+								Key:     compactRevKey,
 								Value:   curValue,
 								Version: version,
 							},

--- a/pkg/server/create.go
+++ b/pkg/server/create.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -29,6 +30,10 @@ func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest
 	}
 
 	rev, err := l.backend.Create(ctx, string(put.Key), put.Value, put.Lease)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("CREATE key=%s, currentRev=%d", put.Key, rev)
+	}
+
 	if err == ErrKeyExists {
 		return &etcdserverpb.TxnResponse{
 			Header:    txnHeader(rev),

--- a/pkg/server/delete.go
+++ b/pkg/server/delete.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -29,6 +30,10 @@ func isDelete(txn *etcdserverpb.TxnRequest) (int64, string, bool) {
 
 func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) (*etcdserverpb.TxnResponse, error) {
 	rev, kv, ok, err := l.backend.Delete(ctx, key, revision)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("DELETE key=%s, revision=%d, currentRev=%d", key, revision, rev)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/get.go
+++ b/pkg/server/get.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/sirupsen/logrus"
@@ -12,15 +13,16 @@ func (l *LimitedServer) get(ctx context.Context, r *etcdserverpb.RangeRequest) (
 		return nil, unsupported("limit")
 	}
 
-	key := string(r.Key)
 	// redirect apiserver get to the substitute compact revision key
 	// response is fixed up in toKV()
-	if key == compactRevKey {
-		key = compactRevAPI
+	if bytes.Equal(r.Key, compactRevKey) {
+		r.Key = compactRevAPI
 	}
 
-	rev, kv, err := l.backend.Get(ctx, key, r.Revision, r.KeysOnly)
-	logrus.Tracef("GET key=%s, revision=%d, currentRev=%d, keysOnly=%v", key, r.Revision, rev, r.KeysOnly)
+	rev, kv, err := l.backend.Get(ctx, string(r.Key), r.Revision, r.KeysOnly)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("GET key=%s, revision=%d, currentRev=%d, keysOnly=%v", r.Key, r.Revision, rev, r.KeysOnly)
+	}
 	resp := &RangeResponse{
 		Header: txnHeader(rev),
 	}

--- a/pkg/server/kv.go
+++ b/pkg/server/kv.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 
@@ -92,8 +93,8 @@ func toKV(kv *KeyValue) *mvccpb.KeyValue {
 	}
 	// fix up apiserver watch with correct compact revision key,
 	// version, and value
-	if kv.Key == compactRevAPI {
-		ret.Key = []byte(compactRevKey)
+	if bytes.Equal(ret.Key, compactRevAPI) {
+		ret.Key = compactRevKey
 		ret.Version, ret.Value = DecodeVersion(kv.Value)
 	}
 	return ret

--- a/pkg/server/put.go
+++ b/pkg/server/put.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
@@ -15,13 +16,13 @@ func (l *LimitedServer) Put(ctx context.Context, r *etcdserverpb.PutRequest) (*e
 	}
 
 	var kv *KeyValue
-	key := string(r.Key)
 	// redirect apiserver get to the substitute compact revision key
 	// response is fixed up in toKV()
-	if key == compactRevKey {
-		key = compactRevAPI
+	if bytes.Equal(r.Key, compactRevKey) {
+		r.Key = compactRevAPI
 	}
 
+	key := string(r.Key)
 	rev, err := l.backend.Create(ctx, key, r.Value, r.Lease)
 	if err == ErrKeyExists {
 		rev, kv, err = l.backend.Get(ctx, key, rev, false)

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -92,6 +92,10 @@ type Event struct {
 	PrevKV *KeyValue
 }
 
+func (e *Event) InRange(key, end string) bool {
+	return e != nil && e.KV != nil && (key == "" || (end != "" && e.KV.Key >= key && e.KV.Key < end) || e.KV.Key == key)
+}
+
 type WatchResult struct {
 	CurrentRevision int64
 	CompactRevision int64

--- a/pkg/server/update.go
+++ b/pkg/server/update.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -23,14 +24,15 @@ func isUpdate(txn *etcdserverpb.TxnRequest) (int64, string, []byte, int64, bool)
 	return 0, "", nil, 0, false
 }
 
-func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value []byte, lease int64) (*etcdserverpb.TxnResponse, error) {
+func (l *LimitedServer) update(ctx context.Context, revision int64, key string, value []byte, lease int64) (*etcdserverpb.TxnResponse, error) {
 	var (
 		kv  *KeyValue
+		rev int64
 		ok  bool
 		err error
 	)
 
-	if rev == 0 {
+	if revision == 0 {
 		rev, err = l.backend.Create(ctx, key, value, lease)
 		if err == ErrKeyExists {
 			rev, kv, err = l.backend.Get(ctx, key, rev, false)
@@ -38,8 +40,13 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 			ok = true
 		}
 	} else {
-		rev, kv, ok, err = l.backend.Update(ctx, key, value, rev, lease)
+		rev, kv, ok, err = l.backend.Update(ctx, key, value, revision, lease)
 	}
+
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("UPDATE key=%s, revision=%d, currentRev=%d", key, revision, rev)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -15,13 +15,9 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-const (
-	// progressResponsePeriod determines how often broadcast watch progress responses will be sent
-	progressResponsePeriod = 100 * time.Millisecond
-)
-
 var serverID int64
 var watchID int64
+var invalidWatchID int64 = clientv3.InvalidWatchID
 
 // explicit interface check
 var _ etcdserverpb.WatchServer = (*KVServerBridge)(nil)
@@ -39,7 +35,7 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	id := atomic.AddInt64(&serverID, 1)
 	w := watcher{
 		id:       id,
-		server:   &server{ws: ws},
+		server:   &server{ws: ws, maxRev: map[int64]int64{}},
 		backend:  s.limited.backend,
 		watches:  map[int64]func(){},
 		progress: map[int64]chan<- int64{},
@@ -49,7 +45,6 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	logrus.Tracef("WATCH SERVER CREATE server=%d", w.id)
 
 	go util.UntilWithContext(ws.Context(), s.getProgressReportInterval(), w.ProgressIfSynced, false)
-	go util.UntilWithContext(ws.Context(), progressResponsePeriod, w.ProgressAll, false)
 
 	for {
 		msg, err := ws.Recv()
@@ -78,7 +73,7 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 // and watch progress notifications.
 type server struct {
 	sync.Mutex
-	maxRevision int64
+	maxRev map[int64]int64
 
 	ws etcdserverpb.Watch_WatchServer
 }
@@ -86,11 +81,25 @@ type server struct {
 func (s *server) Send(wr *etcdserverpb.WatchResponse) error {
 	s.Lock()
 	defer s.Unlock()
-	if wr != nil && wr.Header != nil && wr.Header.Revision > 0 {
-		if wr.Header.Revision > s.maxRevision {
-			s.maxRevision = wr.Header.Revision
+	if wr != nil && wr.Header != nil {
+		if wr.WatchId != invalidWatchID && wr.Created {
+			s.maxRev[wr.WatchId] = wr.Header.Revision
+		} else if wr.WatchId != invalidWatchID && wr.Canceled {
+			delete(s.maxRev, wr.WatchId)
 		} else {
-			wr.Header.Revision = s.maxRevision
+			for id, rev := range s.maxRev {
+				if wr.WatchId == invalidWatchID || wr.WatchId == id {
+					if wr.Header.Revision > rev {
+						s.maxRev[id] = wr.Header.Revision
+					} else if len(wr.Events) > 0 {
+						// Only progress notifications should ever re-send an already-seen revision; if we try to
+						// send events with an old revision the apiserver watch cache will ignore the event and
+						// become permanently desynced. Even if we return an error here and close the watch, the
+						// watcher will resume AFTER the already-seen revision, and remain desynced.
+						logrus.Fatalf("WATCH SEND EVENTS FOR PAST REVISION id=%d, events=%d, revision=%d, maxRevision=%d", wr.WatchId, len(wr.Events), wr.Header.Revision, rev)
+					}
+				}
+			}
 		}
 	}
 	return s.ws.Send(wr)
@@ -294,7 +303,7 @@ func (w *watcher) CancelEarly(ctx context.Context, earlyErr error) {
 
 	err = w.server.Send(&etcdserverpb.WatchResponse{
 		Header:       txnHeader(rev),
-		WatchId:      clientv3.InvalidWatchID,
+		WatchId:      invalidWatchID,
 		Canceled:     true,
 		Created:      true,
 		CancelReason: earlyErr.Error(),
@@ -346,16 +355,18 @@ func (w *watcher) Close() {
 
 // Progress requests a progress report if all watchers are synced.
 // The apiserver may spam progress requests every 100ms while waiting for caches to sync.
-// This handler just sets a flag indicating that notification has been requested;
-// a polling goroutine periodically checks the flag and sends a notification if all
-// watchers are synced.
+// This handler sets a flag indicating that notification has been requested and
+// starts a goroutine to check the flag and send a notification if all watchers
+// are synced.
 // Ref: https://github.com/etcd-io/etcd/blob/v3.5.27/server/mvcc/watchable_store.go#L519-L523
 // Ref: https://github.com/kubernetes/kubernetes/blob/v1.35.1/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go#L34-L36
 func (w *watcher) Progress(ctx context.Context) {
 	logrus.Tracef("WATCH REQUEST PROGRESS server=%d", w.id)
 	w.RLock()
 	defer w.RUnlock()
-	w.notify.Store(true)
+	if w.notify.CompareAndSwap(false, true) {
+		go w.ProgressAll(ctx)
+	}
 }
 
 // ProgressAll sends a broadcast watch progress notification if all
@@ -366,7 +377,6 @@ func (w *watcher) ProgressAll(ctx context.Context) {
 	}
 
 	// If all watchers are synced, send a broadcast progress notification with the latest revision.
-	id := int64(clientv3.InvalidWatchID)
 	rev, err := w.backend.CurrentRevision(ctx)
 	if err != nil {
 		logrus.Errorf("Failed to get current revision for ProgressNotify: %v", err)
@@ -392,8 +402,8 @@ func (w *watcher) ProgressAll(ctx context.Context) {
 		}
 	}
 
-	logrus.Tracef("WATCH SEND PROGRESS server=%d, id=%d, revision=%d", w.id, id, rev)
-	go w.server.Send(&etcdserverpb.WatchResponse{Header: txnHeader(rev), WatchId: id})
+	logrus.Tracef("WATCH SEND PROGRESS server=%d, id=%d, revision=%d", w.id, invalidWatchID, rev)
+	go w.server.Send(&etcdserverpb.WatchResponse{Header: txnHeader(rev), WatchId: invalidWatchID})
 }
 
 // ProgressIfSynced sends a progress report on any channels that are synced.
@@ -405,13 +415,13 @@ func (w *watcher) ProgressIfSynced(ctx context.Context) {
 		return
 	}
 
-	revision, err := w.backend.CurrentRevision(ctx)
+	rev, err := w.backend.CurrentRevision(ctx)
 	if err != nil {
 		logrus.Errorf("Failed to get current revision for ProgressNotify: %v", err)
 		return
 	}
 
-	w.backend.WaitForSyncTo(revision)
+	w.backend.WaitForSyncTo(rev)
 
 	w.RLock()
 	defer w.RUnlock()
@@ -419,7 +429,7 @@ func (w *watcher) ProgressIfSynced(ctx context.Context) {
 	// Send revision to all synced channels
 	for _, progressCh := range w.progress {
 		select {
-		case progressCh <- revision:
+		case progressCh <- rev:
 		default:
 		}
 	}

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"math/rand"
 	"sync"
@@ -132,15 +133,15 @@ func (w *watcher) Create(ctx context.Context, r *etcdserverpb.WatchCreateRequest
 	id := atomic.AddInt64(&watchID, 1)
 	w.watches[id] = cancel
 
+	// redirect apiserver watches to the substitute compact revision key
+	// response is fixed up in toKV()
+	if bytes.Equal(r.Key, compactRevKey) {
+		r.Key = compactRevAPI
+	}
+
 	key := string(r.Key)
 	end := string(r.RangeEnd)
 	startRevision := r.StartRevision
-
-	// redirect apiserver watches to the substitute compact revision key
-	// response is fixed up in toKV()
-	if key == compactRevKey {
-		key = compactRevAPI
-	}
 
 	var progressCh chan int64
 	if r.ProgressNotify {

--- a/pkg/ttl/ttl.go
+++ b/pkg/ttl/ttl.go
@@ -32,7 +32,6 @@ const (
 )
 
 type entry struct {
-	key         string
 	modRevision int64
 	expiredAt   time.Time
 }
@@ -143,16 +142,16 @@ func handle(ctx context.Context, b server.Backend, mu *sync.RWMutex, queue workq
 		return true
 	}
 
-	logrus.Tracef("TTL delete key=%v modRev=%v", e.key, e.modRevision)
-	if _, _, _, err := b.Delete(ctx, e.key, e.modRevision); err != nil && !errors.Is(err, context.Canceled) {
-		logrus.Errorf("TTL delete trigger failed for key=%v: %v, requeuing", e.key, err)
-		queue.AddAfter(e.key, retryInterval)
+	logrus.Tracef("TTL delete key=%v modRev=%v", key, e.modRevision)
+	if _, _, _, err := b.Delete(ctx, key, e.modRevision); err != nil && !errors.Is(err, context.Canceled) {
+		logrus.Errorf("TTL delete trigger failed for key=%v: %v, requeuing", key, err)
+		queue.AddAfter(key, retryInterval)
 		return true
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	delete(store, e.key)
+	delete(store, key)
 	return true
 }
 
@@ -166,10 +165,14 @@ func save(mu *sync.RWMutex, store map[string]*entry, kv *server.KeyValue) time.D
 	mu.Lock()
 	defer mu.Unlock()
 	expires := time.Duration(kv.Lease) * time.Second
-	store[kv.Key] = &entry{
-		key:         kv.Key,
-		modRevision: kv.ModRevision,
-		expiredAt:   time.Now().Add(expires),
+	if e, ok := store[kv.Key]; ok {
+		e.modRevision = kv.ModRevision
+		e.expiredAt = time.Now().Add(expires)
+	} else {
+		store[kv.Key] = &entry{
+			modRevision: kv.ModRevision,
+			expiredAt:   time.Now().Add(expires),
+		}
 	}
 	return expires
 }


### PR DESCRIPTION
Fixes issue where notifications waiting on watch to sync to revision would not wake until the next poll cycle - which could be up to 1 second if no inserts occur to wake the poller early.

Also replaces dedicated progress-request polling goroutine with on-demand goroutine created when new progress is requested. CAS on the notification bool ensures that multiple goroutines do not stack.

The combination of the two delays (100ms notify interval, plus up to 1sec delay for sync) were creating significant delays in DeleteCollection requests, which are used by the namespace controller to remove all resources from a namespace when it is deleted. DeleteCollection relies on progress notification requests to ensure that apiserver caches are synced with etcd before deleting things.

K3s issue:
* https://github.com/k3s-io/k3s/issues/14399