### PR TITLE
Fix delayed watch progress notifications

### DIFF
--- a/pkg/broadcaster/cond.go
+++ b/pkg/broadcaster/cond.go
@@ -1,0 +1,44 @@
+package broadcaster
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Cond is a wrapper around sync.Cond that facilitates
+// waiting for a broadcaster to signal that is has seen
+// a specific revision.
+type Cond struct {
+	cond     *sync.Cond
+	revision atomic.Int64
+}
+
+// NewCond createds a new Cond instance, using sync.Mutex as the lock primitive.
+func NewCond() *Cond {
+	return &Cond{cond: sync.NewCond(&sync.Mutex{})}
+}
+
+// Broadcast stores revision, and broadcasts
+func (c *Cond) Broadcast(revision int64) {
+	c.cond.L.Lock()
+	c.revision.Store(revision)
+	c.cond.Broadcast()
+	c.cond.L.Unlock()
+}
+
+// Wait blocks until Broadcast is called, and revision is greater than or equal the specified revision.
+// Context cancellation will break out of continued waiting on the channel, but may continue
+// to block if Broadcast is not called again after the context is cancelled.
+func (c *Cond) Wait(ctx context.Context, revision int64) {
+	c.cond.L.Lock()
+	for ctx.Err() == nil && c.revision.Load() < revision {
+		c.cond.Wait()
+	}
+	c.cond.L.Unlock()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Millisecond):
+	}
+}

--- a/pkg/drivers/memory/memory.go
+++ b/pkg/drivers/memory/memory.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/k3s-io/kine/pkg/broadcaster"
 	"github.com/k3s-io/kine/pkg/drivers"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/k3s-io/kine/pkg/ttl"
@@ -20,8 +21,9 @@ func init() {
 func New(ctx context.Context, wg *sync.WaitGroup, cfg *drivers.Config) (bool, server.Backend, error) {
 	logrus.Info("using in-memory backend")
 	return false, &Memory{
-		keys:     btree.NewMap[string, []*entry](0),
-		notifyCh: make(chan struct{}),
+		keys:      btree.NewMap[string, []*entry](0),
+		notifyCh:  make(chan struct{}),
+		polledRev: broadcaster.NewCond(),
 	}, nil
 }
 
@@ -53,6 +55,7 @@ type Memory struct {
 	mu              sync.RWMutex
 	currentRevision atomic.Int64
 	compactRevision int64
+	polledRev       *broadcaster.Cond
 
 	log  []*entry
 	keys *btree.Map[string, []*entry]
@@ -91,7 +94,9 @@ func (m *Memory) DbSize(ctx context.Context) (int64, error) {
 	return size, nil
 }
 
-func (m *Memory) WaitForSyncTo(revision int64) {}
+func (m *Memory) WaitForSyncTo(ctx context.Context, revision int64) {
+	m.polledRev.Wait(ctx, revision)
+}
 
 // nextRevision allocates and returns the next revision. Increment is
 // atomic; callers still need m.mu (write) when pairing the new revision
@@ -110,18 +115,19 @@ func (m *Memory) appendEntry(e *entry) {
 		e.prev = hist[len(hist)-1]
 	}
 	m.keys.Set(e.key, append(hist, e))
-	m.broadcast()
+	m.broadcast(e.revision)
 }
 
 // broadcast wakes every goroutine currently blocked on getNotifyCh.
 // Implemented as close-and-replace rather than sync.Cond.Broadcast so that
 // waiters can select on ctx.Done() alongside the wake — sync.Cond.Wait()
 // can't be combined with context cancellation without a helper goroutine.
-func (m *Memory) broadcast() {
+func (m *Memory) broadcast(revision int64) {
 	m.notifyMu.Lock()
 	close(m.notifyCh)
 	m.notifyCh = make(chan struct{})
 	m.notifyMu.Unlock()
+	m.polledRev.Broadcast(revision)
 }
 
 // getNotifyCh returns a channel that will be closed on the next broadcast.
@@ -340,7 +346,7 @@ func (m *Memory) Watch(ctx context.Context, key, end string, startRevision int64
 	m.mu.RUnlock()
 	rev := m.currentRevision.Load()
 
-	events := make(chan []*server.Event, 100)
+	events := make(chan server.Events, 100)
 
 	if startRevision > 0 && startRevision <= compactRev {
 		close(events)
@@ -367,7 +373,7 @@ func (m *Memory) Watch(ctx context.Context, key, end string, startRevision int64
 			notifyCh := m.getNotifyCh()
 
 			m.mu.RLock()
-			var batch []*server.Event
+			var batch server.Events
 			for i := m.logIndexAfter(lastSeen); i < len(m.log); i++ {
 				e := m.log[i]
 				if key == "" || (end != "" && e.key >= key && e.key < end) || e.key == key {

--- a/pkg/drivers/memory/memory_test.go
+++ b/pkg/drivers/memory/memory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k3s-io/kine/pkg/broadcaster"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/k3s-io/kine/pkg/ttl"
 	"github.com/sirupsen/logrus"
@@ -61,8 +62,9 @@ func setupBackend(t *testing.T) (*Memory, context.Context) {
 	logrus.SetLevel(logrus.TraceLevel)
 	logrus.SetOutput(t.Output())
 	b := &Memory{
-		keys:     btree.NewMap[string, []*entry](0),
-		notifyCh: make(chan struct{}),
+		keys:      btree.NewMap[string, []*entry](0),
+		notifyCh:  make(chan struct{}),
+		polledRev: broadcaster.NewCond(),
 	}
 	ctx := t.Context()
 	t.Cleanup(func() { logrus.SetOutput(os.Stdout) })

--- a/pkg/drivers/nats/backend.go
+++ b/pkg/drivers/nats/backend.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/k3s-io/kine/pkg/broadcaster"
 	"github.com/k3s-io/kine/pkg/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
@@ -56,13 +57,14 @@ func (d *natsData) Decode(e jetstream.KeyValueEntry) error {
 }
 
 // Ensure Backend implements server.Backend.
-var _ server.Backend = (&Backend{})
+var _ server.Backend = &Backend{}
 
 type Backend struct {
 	kv               *KeyValue
 	l                *logrus.Logger
 	compactInterval  time.Duration
 	compactMinRetain int64
+	polledRev        *broadcaster.Cond
 	ctx              context.Context
 }
 
@@ -416,7 +418,7 @@ func (b *Backend) List(ctx context.Context, key, end string, limit, maxRevision 
 }
 
 func (b *Backend) Watch(ctx context.Context, key, end string, startRevision int64) server.WatchResult {
-	events := make(chan []*server.Event, 32)
+	events := make(chan server.Events, 32)
 
 	if startRevision > 0 && startRevision <= b.kv.compactRev.Load() {
 		return server.WatchResult{
@@ -482,7 +484,7 @@ func (b *Backend) Watch(ctx context.Context, key, end string, startRevision int6
 					continue
 				}
 
-				event := server.Event{
+				event := &server.Event{
 					Create: nd.Create,
 					Delete: nd.Delete,
 					KV:     nd.KV,
@@ -498,7 +500,10 @@ func (b *Backend) Watch(ctx context.Context, key, end string, startRevision int6
 					}
 				}
 
-				events <- []*server.Event{&event}
+				events <- server.Events{event}
+				if key == "" {
+					b.polledRev.Broadcast(event.KV.ModRevision)
+				}
 			}
 		}
 	}()
@@ -566,8 +571,8 @@ func (b *Backend) Compact(ctx context.Context, revision int64) (int64, error) {
 	return currRev, nil
 }
 
-func (b *Backend) WaitForSyncTo(revision int64) {
-	// no-op
+func (b *Backend) WaitForSyncTo(ctx context.Context, revision int64) {
+	b.polledRev.Wait(ctx, revision)
 }
 
 // compactor runs periodic automatic compaction in the background.

--- a/pkg/drivers/nats/backend_test.go
+++ b/pkg/drivers/nats/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/k3s-io/kine/pkg/broadcaster"
 	kserver "github.com/k3s-io/kine/pkg/server"
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats-server/v2/test"
@@ -38,8 +39,9 @@ func setupBackend(ctx context.Context, wg *sync.WaitGroup, t *testing.T) (*serve
 	l := logrus.New()
 	l.SetOutput(io.Discard)
 
-	b := Backend{
-		l: l,
+	b := &Backend{
+		l:         l,
+		polledRev: broadcaster.NewCond(),
 	}
 
 	ekv := NewKeyValue("local", wg, bkt, js, 10, b.Delete)
@@ -49,7 +51,7 @@ func setupBackend(ctx context.Context, wg *sync.WaitGroup, t *testing.T) (*serve
 	err = b.Start(ctx)
 	noErr(t, err)
 
-	return ns, nc, &b
+	return ns, nc, b
 }
 
 func TestBackend_Create(t *testing.T) {

--- a/pkg/drivers/nats/logger.go
+++ b/pkg/drivers/nats/logger.go
@@ -123,6 +123,6 @@ func (b *BackendLogger) Compact(ctx context.Context, revision int64) (int64, err
 	return b.backend.Compact(ctx, revision)
 }
 
-func (b *BackendLogger) WaitForSyncTo(revision int64) {
-	b.backend.WaitForSyncTo(revision)
+func (b *BackendLogger) WaitForSyncTo(ctx context.Context, revision int64) {
+	b.backend.WaitForSyncTo(ctx, revision)
 }

--- a/pkg/drivers/nats/new.go
+++ b/pkg/drivers/nats/new.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/k3s-io/kine/pkg/broadcaster"
 	"github.com/k3s-io/kine/pkg/drivers"
 	natsserver "github.com/k3s-io/kine/pkg/drivers/nats/server"
 	"github.com/k3s-io/kine/pkg/server"
@@ -209,10 +210,11 @@ func newBackend(ctx context.Context, wg *sync.WaitGroup, connection string, tlsI
 		name = "embedded"
 	}
 
-	b := Backend{
+	b := &Backend{
 		l:                l,
 		compactInterval:  compactInterval,
 		compactMinRetain: compactMinRetain,
+		polledRev:        broadcaster.NewCond(),
 	}
 
 	kv := NewKeyValue(name, wg, bucket, js, int(config.revHistory), b.Delete)
@@ -223,7 +225,7 @@ func newBackend(ctx context.Context, wg *sync.WaitGroup, connection string, tlsI
 
 	return &BackendLogger{
 		logger:    l,
-		backend:   &b,
+		backend:   b,
 		threshold: config.slowThreshold,
 	}, nil
 }

--- a/pkg/drivers/t4/backend.go
+++ b/pkg/drivers/t4/backend.go
@@ -190,7 +190,7 @@ func (b *backend) Watch(ctx context.Context, key, end string, revision int64) ks
 	compactRev := b.node.CompactRevision()
 
 	errCh := make(chan error, 1)
-	eventCh := make(chan []*kserver.Event, 64)
+	eventCh := make(chan kserver.Events, 64)
 
 	if revision > 0 && revision <= compactRev {
 		errCh <- kserver.ErrCompacted
@@ -218,7 +218,7 @@ func (b *backend) Watch(ctx context.Context, key, end string, revision int64) ks
 		// loop only takes immediately available events.
 		const maxBatch = 64
 		for ev := range ch {
-			batch := []*kserver.Event{toServerEvent(&ev)}
+			batch := kserver.Events{toServerEvent(&ev)}
 		drain:
 			for len(batch) < maxBatch {
 				select {
@@ -262,8 +262,13 @@ func (b *backend) Compact(ctx context.Context, revision int64) (int64, error) {
 	return revision, nil
 }
 
-func (b *backend) WaitForSyncTo(revision int64) {
-	_ = b.node.WaitForRevision(context.Background(), revision)
+func (b *backend) WaitForSyncTo(ctx context.Context, revision int64) {
+	if err := b.node.WaitForRevision(ctx, revision); err == nil {
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Millisecond):
+		}
+	}
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -308,7 +308,8 @@ func (l *loggingServerStream) SendMsg(m any) error {
 	start := time.Now()
 	defer func() {
 		if wr, ok := m.(*etcdserverpb.WatchResponse); ok {
-			logrus.Tracef("STREAM STATS WATCH SEND DONE client=%s, id=%d, revision=%d, events=%d, size=%d, reason=%q, time=%s", l.clientAddr, wr.WatchId, wr.Header.Revision, len(wr.Events), wr.Size(), wr.CancelReason, time.Since(start).Truncate(time.Microsecond))
+			logrus.Tracef("STREAM STATS WATCH SEND DONE client=%s, id=%d, revision=%d, events=%d, size=%d, created=%v, canceled=%v, reason=%q, time=%s",
+				l.clientAddr, wr.WatchId, wr.Header.Revision, len(wr.Events), wr.Size(), wr.Created, wr.Canceled, wr.CancelReason, time.Since(start).Truncate(time.Microsecond))
 			return
 		}
 		if p, ok := m.(proto.Message); ok {

--- a/pkg/logstructured/logstructured.go
+++ b/pkg/logstructured/logstructured.go
@@ -21,7 +21,7 @@ type Log interface {
 	Append(ctx context.Context, event *server.Event) (int64, error)
 	DbSize(ctx context.Context) (int64, error)
 	Compact(ctx context.Context, revision int64) (int64, error)
-	WaitForSyncTo(revision int64)
+	WaitForSyncTo(ctx context.Context, revision int64)
 }
 
 type LogStructured struct {
@@ -226,7 +226,7 @@ func (l *LogStructured) Watch(ctx context.Context, key, end string, revision int
 	ctx, cancel := context.WithCancel(ctx)
 	readChan := l.log.Watch(ctx, key, end)
 
-	result := make(chan []*server.Event, 100)
+	result := make(chan server.Events, 100)
 	errc := make(chan error, 1)
 	wr := server.WatchResult{Events: result, Errorc: errc}
 
@@ -293,6 +293,6 @@ func (l *LogStructured) Compact(ctx context.Context, revision int64) (int64, err
 	return l.log.Compact(ctx, revision)
 }
 
-func (l *LogStructured) WaitForSyncTo(revision int64) {
-	l.log.WaitForSyncTo(revision)
+func (l *LogStructured) WaitForSyncTo(ctx context.Context, revision int64) {
+	l.log.WaitForSyncTo(ctx, revision)
 }

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -488,6 +488,12 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 	defer close(result)
 
 	for {
+		// broadcast polled revision to reflect what rows have already been sent to event channel
+		s.Lock()
+		s.polledRev.Store(pollRevision)
+		s.polled.Broadcast()
+		s.Unlock()
+
 		if waitForMore {
 			select {
 			case <-s.ctx.Done():
@@ -499,13 +505,6 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			case <-wait.C:
 			}
 		}
-		waitForMore = true
-
-		//  update polled revision to reflect what rows have already been seen
-		s.Lock()
-		s.polledRev.Store(pollRevision)
-		s.polled.Broadcast()
-		s.Unlock()
 
 		rows, err := s.d.After(s.ctx, "", "", pollRevision, s.pollBatchSize)
 		if err != nil {
@@ -516,6 +515,7 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		}
 
 		_, _, events, err := RowsToEvents(rows, true, true)
+		waitForMore = len(events) < 100
 		if err != nil {
 			logrus.Errorf("fail to convert rows changes: %v", err)
 			continue
@@ -528,8 +528,6 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		if len(events) == 0 {
 			continue
 		}
-
-		waitForMore = len(events) < 100
 
 		var (
 			rev        = pollRevision

--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,15 +18,12 @@ import (
 const minCompactBatchSize = 100
 
 type SQLLog struct {
-	sync.RWMutex
-
 	d                     server.Dialect
-	broadcaster           broadcaster.Broadcaster
+	broadcaster           *broadcaster.Broadcaster
+	polledRev             *broadcaster.Cond
 	ctx                   context.Context
 	notify                chan int64
 	currentRev            atomic.Int64
-	polledRev             atomic.Int64
-	polled                *sync.Cond
 	compactInterval       time.Duration
 	compactIntervalJitter int
 	compactTimeout        time.Duration
@@ -39,6 +35,8 @@ type SQLLog struct {
 func New(d server.Dialect, compactInterval time.Duration, compactIntervalJitter int, compactTimeout time.Duration, compactMinRetain int64, compactBatchSize int64, pollBatchSize int64) *SQLLog {
 	l := &SQLLog{
 		d:                     d,
+		broadcaster:           &broadcaster.Broadcaster{},
+		polledRev:             broadcaster.NewCond(),
 		notify:                make(chan int64, 1024),
 		compactInterval:       compactInterval,
 		compactIntervalJitter: compactIntervalJitter,
@@ -47,7 +45,6 @@ func New(d server.Dialect, compactInterval time.Duration, compactIntervalJitter 
 		compactBatchSize:      compactBatchSize,
 		pollBatchSize:         pollBatchSize,
 	}
-	l.polled = sync.NewCond(l.RLocker())
 	return l
 }
 
@@ -489,10 +486,7 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 
 	for {
 		// broadcast polled revision to reflect what rows have already been sent to event channel
-		s.Lock()
-		s.polledRev.Store(pollRevision)
-		s.polled.Broadcast()
-		s.Unlock()
+		s.polledRev.Broadcast(pollRevision)
 
 		if waitForMore {
 			select {
@@ -753,10 +747,6 @@ func (s *SQLLog) Compact(ctx context.Context, targetCompactRev int64) (int64, er
 	return currentRev, nil
 }
 
-func (s *SQLLog) WaitForSyncTo(revision int64) {
-	s.polled.L.Lock()
-	for s.polledRev.Load() < revision {
-		s.polled.Wait()
-	}
-	s.polled.L.Unlock()
+func (s *SQLLog) WaitForSyncTo(ctx context.Context, revision int64) {
+	s.polledRev.Wait(ctx, revision)
 }

--- a/pkg/server/create.go
+++ b/pkg/server/create.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -29,6 +30,10 @@ func (l *LimitedServer) create(ctx context.Context, put *etcdserverpb.PutRequest
 	}
 
 	rev, err := l.backend.Create(ctx, string(put.Key), put.Value, put.Lease)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("CREATE key=%s, currentRev=%d", put.Key, rev)
+	}
+
 	if err == ErrKeyExists {
 		return &etcdserverpb.TxnResponse{
 			Header:    txnHeader(rev),

--- a/pkg/server/delete.go
+++ b/pkg/server/delete.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -29,6 +30,10 @@ func isDelete(txn *etcdserverpb.TxnRequest) (int64, string, bool) {
 
 func (l *LimitedServer) delete(ctx context.Context, key string, revision int64) (*etcdserverpb.TxnResponse, error) {
 	rev, kv, ok, err := l.backend.Delete(ctx, key, revision)
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("DELETE key=%s, revision=%d, currentRev=%d", key, revision, rev)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -37,7 +37,7 @@ type Backend interface {
 	DbSize(ctx context.Context) (int64, error)
 	CurrentRevision(ctx context.Context) (int64, error)
 	Compact(ctx context.Context, revision int64) (int64, error)
-	WaitForSyncTo(revision int64)
+	WaitForSyncTo(ctx context.Context, revision int64)
 }
 
 type Dialect interface {
@@ -99,7 +99,7 @@ func (e *Event) InRange(key, end string) bool {
 type WatchResult struct {
 	CurrentRevision int64
 	CompactRevision int64
-	Events          <-chan []*Event
+	Events          <-chan Events
 	Errorc          <-chan error
 }
 

--- a/pkg/server/update.go
+++ b/pkg/server/update.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
@@ -23,14 +24,15 @@ func isUpdate(txn *etcdserverpb.TxnRequest) (int64, string, []byte, int64, bool)
 	return 0, "", nil, 0, false
 }
 
-func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value []byte, lease int64) (*etcdserverpb.TxnResponse, error) {
+func (l *LimitedServer) update(ctx context.Context, revision int64, key string, value []byte, lease int64) (*etcdserverpb.TxnResponse, error) {
 	var (
 		kv  *KeyValue
+		rev int64
 		ok  bool
 		err error
 	)
 
-	if rev == 0 {
+	if revision == 0 {
 		rev, err = l.backend.Create(ctx, key, value, lease)
 		if err == ErrKeyExists {
 			rev, kv, err = l.backend.Get(ctx, key, rev, false)
@@ -38,8 +40,13 @@ func (l *LimitedServer) update(ctx context.Context, rev int64, key string, value
 			ok = true
 		}
 	} else {
-		rev, kv, ok, err = l.backend.Update(ctx, key, value, rev, lease)
+		rev, kv, ok, err = l.backend.Update(ctx, key, value, revision, lease)
 	}
+
+	if logrus.IsLevelEnabled(logrus.TraceLevel) {
+		logrus.Tracef("UPDATE key=%s, revision=%d, currentRev=%d", key, revision, rev)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -384,7 +384,7 @@ func (w *watcher) ProgressAll(ctx context.Context) {
 	}
 
 	// ensure that poll loop is caught up with current revision before checking for sync
-	w.backend.WaitForSyncTo(rev)
+	w.backend.WaitForSyncTo(ctx, rev)
 
 	w.RLock()
 	defer w.RUnlock()
@@ -421,7 +421,7 @@ func (w *watcher) ProgressIfSynced(ctx context.Context) {
 		return
 	}
 
-	w.backend.WaitForSyncTo(rev)
+	w.backend.WaitForSyncTo(ctx, rev)
 
 	w.RLock()
 	defer w.RUnlock()

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -35,7 +35,7 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	id := atomic.AddInt64(&serverID, 1)
 	w := watcher{
 		id:       id,
-		server:   &server{ws: ws, maxRev: map[int64]int64{}},
+		server:   &server{ws: ws, maxRev: map[int64]*revAt{}},
 		backend:  s.limited.backend,
 		watches:  map[int64]func(){},
 		progress: map[int64]chan<- int64{},
@@ -73,9 +73,14 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 // and watch progress notifications.
 type server struct {
 	sync.Mutex
-	maxRev map[int64]int64
+	maxRev map[int64]*revAt
 
 	ws etcdserverpb.Watch_WatchServer
+}
+
+type revAt struct {
+	r int64
+	t time.Time
 }
 
 func (s *server) Send(wr *etcdserverpb.WatchResponse) error {
@@ -83,20 +88,21 @@ func (s *server) Send(wr *etcdserverpb.WatchResponse) error {
 	defer s.Unlock()
 	if wr != nil && wr.Header != nil {
 		if wr.WatchId != invalidWatchID && wr.Created {
-			s.maxRev[wr.WatchId] = wr.Header.Revision
+			s.maxRev[wr.WatchId] = &revAt{r: wr.Header.Revision, t: time.Now()}
 		} else if wr.WatchId != invalidWatchID && wr.Canceled {
 			delete(s.maxRev, wr.WatchId)
 		} else {
 			for id, rev := range s.maxRev {
 				if wr.WatchId == invalidWatchID || wr.WatchId == id {
-					if wr.Header.Revision > rev {
-						s.maxRev[id] = wr.Header.Revision
+					if wr.Header.Revision > rev.r {
+						rev.r = wr.Header.Revision
+						rev.t = time.Now()
 					} else if len(wr.Events) > 0 {
 						// Only progress notifications should ever re-send an already-seen revision; if we try to
 						// send events with an old revision the apiserver watch cache will ignore the event and
 						// become permanently desynced. Even if we return an error here and close the watch, the
 						// watcher will resume AFTER the already-seen revision, and remain desynced.
-						logrus.Fatalf("WATCH SEND EVENTS FOR PAST REVISION id=%d, events=%d, revision=%d, maxRevision=%d", wr.WatchId, len(wr.Events), wr.Header.Revision, rev)
+						logrus.Fatalf("WATCH SEND EVENTS FOR PAST REVISION id=%d, events=%d, revision=%d, maxRevision=%d, age=%s", wr.WatchId, len(wr.Events), wr.Header.Revision, rev.r, time.Since(rev.t))
 					}
 				}
 			}

--- a/pkg/server/watch.go
+++ b/pkg/server/watch.go
@@ -15,13 +15,9 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-const (
-	// progressResponsePeriod determines how often broadcast watch progress responses will be sent
-	progressResponsePeriod = 100 * time.Millisecond
-)
-
 var serverID int64
 var watchID int64
+var invalidWatchID int64 = clientv3.InvalidWatchID
 
 // explicit interface check
 var _ etcdserverpb.WatchServer = (*KVServerBridge)(nil)
@@ -39,7 +35,7 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	id := atomic.AddInt64(&serverID, 1)
 	w := watcher{
 		id:       id,
-		server:   &server{ws: ws},
+		server:   &server{ws: ws, maxRev: map[int64]int64{}},
 		backend:  s.limited.backend,
 		watches:  map[int64]func(){},
 		progress: map[int64]chan<- int64{},
@@ -49,7 +45,6 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 	logrus.Tracef("WATCH SERVER CREATE server=%d", w.id)
 
 	go util.UntilWithContext(ws.Context(), s.getProgressReportInterval(), w.ProgressIfSynced, false)
-	go util.UntilWithContext(ws.Context(), progressResponsePeriod, w.ProgressAll, false)
 
 	for {
 		msg, err := ws.Recv()
@@ -78,7 +73,7 @@ func (s *KVServerBridge) Watch(ws etcdserverpb.Watch_WatchServer) error {
 // and watch progress notifications.
 type server struct {
 	sync.Mutex
-	maxRevision int64
+	maxRev map[int64]int64
 
 	ws etcdserverpb.Watch_WatchServer
 }
@@ -86,11 +81,25 @@ type server struct {
 func (s *server) Send(wr *etcdserverpb.WatchResponse) error {
 	s.Lock()
 	defer s.Unlock()
-	if wr != nil && wr.Header != nil && wr.Header.Revision > 0 {
-		if wr.Header.Revision > s.maxRevision {
-			s.maxRevision = wr.Header.Revision
+	if wr != nil && wr.Header != nil {
+		if wr.WatchId != invalidWatchID && wr.Created {
+			s.maxRev[wr.WatchId] = wr.Header.Revision
+		} else if wr.WatchId != invalidWatchID && wr.Canceled {
+			delete(s.maxRev, wr.WatchId)
 		} else {
-			wr.Header.Revision = s.maxRevision
+			for id, rev := range s.maxRev {
+				if wr.WatchId == invalidWatchID || wr.WatchId == id {
+					if wr.Header.Revision > rev {
+						s.maxRev[id] = wr.Header.Revision
+					} else if len(wr.Events) > 0 {
+						// Only progress notifications should ever re-send an already-seen revision; if we try to
+						// send events with an old revision the apiserver watch cache will ignore the event and
+						// become permanently desynced. Even if we return an error here and close the watch, the
+						// watcher will resume AFTER the already-seen revision, and remain desynced.
+						logrus.Fatalf("WATCH SEND EVENTS FOR PAST REVISION id=%d, events=%d, revision=%d, maxRevision=%d", wr.WatchId, len(wr.Events), wr.Header.Revision, rev)
+					}
+				}
+			}
 		}
 	}
 	return s.ws.Send(wr)
@@ -294,7 +303,7 @@ func (w *watcher) CancelEarly(ctx context.Context, earlyErr error) {
 
 	err = w.server.Send(&etcdserverpb.WatchResponse{
 		Header:       txnHeader(rev),
-		WatchId:      clientv3.InvalidWatchID,
+		WatchId:      invalidWatchID,
 		Canceled:     true,
 		Created:      true,
 		CancelReason: earlyErr.Error(),
@@ -346,16 +355,18 @@ func (w *watcher) Close() {
 
 // Progress requests a progress report if all watchers are synced.
 // The apiserver may spam progress requests every 100ms while waiting for caches to sync.
-// This handler just sets a flag indicating that notification has been requested;
-// a polling goroutine periodically checks the flag and sends a notification if all
-// watchers are synced.
+// This handler sets a flag indicating that notification has been requested and
+// starts a goroutine to check the flag and send a notification if all watchers
+// are synced.
 // Ref: https://github.com/etcd-io/etcd/blob/v3.5.27/server/mvcc/watchable_store.go#L519-L523
 // Ref: https://github.com/kubernetes/kubernetes/blob/v1.35.1/staging/src/k8s.io/apiserver/pkg/storage/cacher/progress/watch_progress.go#L34-L36
 func (w *watcher) Progress(ctx context.Context) {
 	logrus.Tracef("WATCH REQUEST PROGRESS server=%d", w.id)
 	w.RLock()
 	defer w.RUnlock()
-	w.notify.Store(true)
+	if w.notify.CompareAndSwap(false, true) {
+		go w.ProgressAll(ctx)
+	}
 }
 
 // ProgressAll sends a broadcast watch progress notification if all
@@ -366,7 +377,6 @@ func (w *watcher) ProgressAll(ctx context.Context) {
 	}
 
 	// If all watchers are synced, send a broadcast progress notification with the latest revision.
-	id := int64(clientv3.InvalidWatchID)
 	rev, err := w.backend.CurrentRevision(ctx)
 	if err != nil {
 		logrus.Errorf("Failed to get current revision for ProgressNotify: %v", err)
@@ -392,8 +402,8 @@ func (w *watcher) ProgressAll(ctx context.Context) {
 		}
 	}
 
-	logrus.Tracef("WATCH SEND PROGRESS server=%d, id=%d, revision=%d", w.id, id, rev)
-	go w.server.Send(&etcdserverpb.WatchResponse{Header: txnHeader(rev), WatchId: id})
+	logrus.Tracef("WATCH SEND PROGRESS server=%d, id=%d, revision=%d", w.id, invalidWatchID, rev)
+	go w.server.Send(&etcdserverpb.WatchResponse{Header: txnHeader(rev), WatchId: invalidWatchID})
 }
 
 // ProgressIfSynced sends a progress report on any channels that are synced.
@@ -405,13 +415,13 @@ func (w *watcher) ProgressIfSynced(ctx context.Context) {
 		return
 	}
 
-	revision, err := w.backend.CurrentRevision(ctx)
+	rev, err := w.backend.CurrentRevision(ctx)
 	if err != nil {
 		logrus.Errorf("Failed to get current revision for ProgressNotify: %v", err)
 		return
 	}
 
-	w.backend.WaitForSyncTo(revision)
+	w.backend.WaitForSyncTo(rev)
 
 	w.RLock()
 	defer w.RUnlock()
@@ -419,7 +429,7 @@ func (w *watcher) ProgressIfSynced(ctx context.Context) {
 	// Send revision to all synced channels
 	for _, progressCh := range w.progress {
 		select {
-		case progressCh <- revision:
+		case progressCh <- rev:
 		default:
 		}
 	}


### PR DESCRIPTION
Fixes issue where notifications waiting on watch to sync to revision would not wake until the next poll cycle - which could be up to 1 second if no inserts occur to wake the poller early.

Also replaces dedicated progress-request polling goroutine with on-demand goroutine created when new progress is requested. CAS on the notification bool ensures that multiple goroutines do not stack.

The combination of the two delays (100ms notify interval, plus up to 1sec delay for sync) were creating significant delays in DeleteCollection requests, which are used by the namespace controller to remove all resources from a namespace when it is deleted. DeleteCollection relies on progress notification requests to ensure that apiserver caches are synced with etcd before deleting things.

K3s issue:
* https://github.com/k3s-io/k3s/issues/14399