### PR TITLE
Surface rows.Err() so interrupted queries are not read as empty results

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -407,6 +407,16 @@ func RowsToEvents(rows *sql.Rows, val, prev bool) (int64, int64, server.Events, 
 		result = append(result, event)
 	}
 
+	// rows.Next() returns false both at the end of the result set and when
+	// the query dies mid-flight (killed session, cancelled statement, broken
+	// connection). Without surfacing rows.Err(), an interrupted query is
+	// indistinguishable from an empty result, which callers interpret as "key
+	// does not exist" — turning transient failures into silent lost updates
+	// (e.g. Delete reporting success without appending a tombstone).
+	if err := rows.Err(); err != nil {
+		return 0, 0, nil, err
+	}
+
 	return rev, compact, result, nil
 }
 

--- a/pkg/logstructured/sqllog/sql_test.go
+++ b/pkg/logstructured/sqllog/sql_test.go
@@ -1,0 +1,144 @@
+package sqllog
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// errRowsDriver returns result sets that yield a configurable number of good
+// rows and then fail from driver.Rows.Next, the way a killed session /
+// cancelled statement / dying connection surfaces mid-resultset. The DSN
+// encodes "<goodRows>|<error message>"; an empty message means a normal EOF.
+type errRowsDriver struct{}
+
+func (d *errRowsDriver) Open(name string) (driver.Conn, error) {
+	parts := strings.SplitN(name, "|", 2)
+	goodRows, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	conn := &errRowsConn{goodRows: goodRows}
+	if len(parts) == 2 && parts[1] != "" {
+		conn.err = errors.New(parts[1])
+	}
+	return conn, nil
+}
+
+type errRowsConn struct {
+	goodRows int
+	err      error
+}
+
+func (c *errRowsConn) Prepare(query string) (driver.Stmt, error) { return &errRowsStmt{c: c}, nil }
+func (c *errRowsConn) Close() error                              { return nil }
+func (c *errRowsConn) Begin() (driver.Tx, error)                 { return nil, driver.ErrSkip }
+
+type errRowsStmt struct{ c *errRowsConn }
+
+func (s *errRowsStmt) Close() error  { return nil }
+func (s *errRowsStmt) NumInput() int { return -1 }
+func (s *errRowsStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, driver.ErrSkip
+}
+func (s *errRowsStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &errRows{remaining: s.c.goodRows, err: s.c.err}, nil
+}
+
+type errRows struct {
+	remaining int
+	err       error
+	emitted   int64
+}
+
+func (r *errRows) Columns() []string {
+	return []string{"id", "compact_revision", "theid", "name", "created", "deleted", "create_revision", "prev_revision", "lease", "value", "old_value"}
+}
+func (r *errRows) Close() error { return nil }
+func (r *errRows) Next(dest []driver.Value) error {
+	if r.remaining == 0 {
+		if r.err != nil {
+			return r.err
+		}
+		return io.EOF
+	}
+	r.remaining--
+	r.emitted++
+	dest[0] = int64(10)          // current revision
+	dest[1] = int64(1)           // compact revision
+	dest[2] = r.emitted          // theid
+	dest[3] = []byte("/key")     // name
+	dest[4] = int64(1)           // created
+	dest[5] = int64(0)           // deleted
+	dest[6] = int64(0)           // create_revision
+	dest[7] = int64(0)           // prev_revision
+	dest[8] = int64(0)           // lease
+	dest[9] = []byte("value")    // value
+	dest[10] = []byte(nil)       // old_value
+	return nil
+}
+
+var errRowsDriverRegistered atomic.Bool
+
+func queryErrRows(t *testing.T, goodRows int, errMsg string) *sql.Rows {
+	t.Helper()
+	if errRowsDriverRegistered.CompareAndSwap(false, true) {
+		sql.Register("err-rows", &errRowsDriver{})
+	}
+	db, err := sql.Open("err-rows", fmt.Sprintf("%d|%s", goodRows, errMsg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("failed to close db: %v", err)
+		}
+	})
+	rows, err := db.Query("SELECT irrelevant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+func TestRowsToEventsCompleteResultSet(t *testing.T) {
+	_, _, events, err := RowsToEvents(queryErrRows(t, 2, ""), true, true)
+	if err != nil {
+		t.Fatalf("expected no error for a complete result set, got %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+}
+
+// A query that dies before yielding its first row must surface the error:
+// treating it as an empty result makes callers conclude the key does not
+// exist, so e.g. logstructured.Delete reports success without writing a
+// tombstone (a silent lost delete).
+func TestRowsToEventsSurfacesErrorBeforeFirstRow(t *testing.T) {
+	_, _, events, err := RowsToEvents(queryErrRows(t, 0, "session is in the kill state"), true, true)
+	if err == nil {
+		t.Fatalf("expected the mid-flight query error, got nil error and %d events", len(events))
+	}
+	if !strings.Contains(err.Error(), "kill state") {
+		t.Fatalf("expected the driver error, got %v", err)
+	}
+}
+
+// A query interrupted after some rows must not be mistaken for a complete,
+// shorter result set.
+func TestRowsToEventsSurfacesMidStreamError(t *testing.T) {
+	_, _, events, err := RowsToEvents(queryErrRows(t, 1, "connection reset"), true, true)
+	if err == nil {
+		t.Fatalf("expected the mid-flight query error, got nil error and %d events", len(events))
+	}
+	if !strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("expected the driver error, got %v", err)
+	}
+}


### PR DESCRIPTION
`RowsToEvents` never checks `rows.Err()` after the `rows.Next()` loop, so a query that dies mid-flight — killed session, deadlock victim, cancelled statement, dropped connection — is indistinguishable from an empty result set.

That empty read propagates as "key does not exist": `logstructured.Delete` treats it as "already deleted" and returns success **without appending a tombstone**, so the client gets `Succeeded: true` while the key is still readable afterwards. Point Gets and prefix Lists can likewise come back spuriously empty, and the CAS create/update flows then run against a wrong base.

I hit this in production-like testing on the SQL Server backend and could reproduce it reliably: run kine over SQL Server while a chaos loop KILLs active sessions on the database every 40ms, with workers doing create → verify → delete cycles through the normal gRPC path. In a 90s run (~6k kills), 72 deletes reported success while the row provably stayed live in the kine table, plus 41 Gets that returned empty right after a successful create. With this patch the same run shows zero anomalies — the interrupted statements surface as errors instead, which clients can retry.

The added tests use a fake driver that fails from `driver.Rows.Next` before the first row and mid-stream; both cases return a nil error on master today.