### PR TITLE
Use sqlite3.NewConnector to access registered driver instance

### DIFF
--- a/pkg/drivers/sqlite/sqlite_nocgo.go
+++ b/pkg/drivers/sqlite/sqlite_nocgo.go
@@ -21,7 +21,11 @@ func newConnector(driverName, dsn string) (*sqliteConnector, error) {
 		return nil, err
 	}
 
-	driver := &sqlite3.Driver{}
+	connector, err := sqlite3.NewConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	driver := connector.Driver().(*sqlite3.Driver)
 	if driverName == "litestream" {
 		driver.RegisterConnectionHook(func(conn sqlite3.ExecQuerierContext, dsn string) error {
 			var err error


### PR DESCRIPTION
User-created `sqlite3.Driver` instances are missing some important private field setup; upstream now recommends using the Connector interface to get at the registered driver for the sake of consistency with the driver returned by `sqlite3.Open()`

See: https://gitlab.com/cznic/sqlite/-/work_items/253