### PR TITLE
fix(t4): allow watching at the compact revision

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/shengdoushi/base58 v1.0.0
 	github.com/sirupsen/logrus v1.9.4
-	github.com/t4db/t4 v1.0.5
+	github.com/t4db/t4 v1.0.6
 	github.com/tidwall/btree v1.8.1
 	github.com/urfave/cli/v2 v2.27.7
 	go.etcd.io/etcd/api/v3 v3.6.13

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/t4db/t4 v1.0.5 h1:AQfzPzka9JjeKQ5AAh44xJomyMhW5xfj8G7vFSQWJIo=
-github.com/t4db/t4 v1.0.5/go.mod h1:j/5by/iUcGJlPUXIbT5zOrEuB0k+XQ4Xg2dHU75+loc=
+github.com/t4db/t4 v1.0.6 h1:yzh5jNFk56Le6y9FzxMeD2IRyH3S4B0VATjolmv0oUE=
+github.com/t4db/t4 v1.0.6/go.mod h1:j/5by/iUcGJlPUXIbT5zOrEuB0k+XQ4Xg2dHU75+loc=
 github.com/tidwall/btree v1.8.1 h1:27ehoXvm5AG/g+1VxLS1SD3vRhp/H7LuEfwNvddEdmA=
 github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VXftj1A=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=

--- a/pkg/drivers/t4/backend.go
+++ b/pkg/drivers/t4/backend.go
@@ -192,7 +192,7 @@ func (b *backend) Watch(ctx context.Context, key, end string, revision int64) ks
 	errCh := make(chan error, 1)
 	eventCh := make(chan []*kserver.Event, 64)
 
-	if revision > 0 && revision <= compactRev {
+	if revision > 0 && revision < compactRev {
 		errCh <- kserver.ErrCompacted
 		close(errCh)
 		close(eventCh)

--- a/pkg/drivers/t4/backend_smoke_test.go
+++ b/pkg/drivers/t4/backend_smoke_test.go
@@ -241,6 +241,43 @@ func TestT4Backend_CompactAndCompactedWatch(t *testing.T) {
 	}
 }
 
+func TestT4Backend_WatchAtCompactRevision(t *testing.T) {
+	b, ctx := newLocalBackend(t)
+
+	rev1, err := b.Create(ctx, "/cw/k", []byte("v1"), 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	rev2, _, _, err := b.Update(ctx, "/cw/k", []byte("v2"), rev1, 0)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if _, err := b.Compact(ctx, rev2); err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+
+	// Watching at the compact revision is required to work and to replay the
+	// event recorded at that revision.
+	wr := b.Watch(ctx, "/cw/", "/cw0", rev2)
+	select {
+	case err, ok := <-wr.Errorc:
+		t.Fatalf("Watch at compact revision: unexpected error %v (chan open: %v)", err, ok)
+	case evs, ok := <-wr.Events:
+		if !ok {
+			t.Fatal("Watch at compact revision: event channel closed")
+		}
+		if len(evs) == 0 {
+			t.Fatal("Watch at compact revision: empty event batch")
+		}
+		if got := evs[0].KV.ModRevision; got != rev2 {
+			t.Errorf("replayed event: want ModRevision %d, got %d", rev2, got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch at compact revision: timeout waiting for replay")
+	}
+}
+
 func TestT4Backend_FutureRevisionRejected(t *testing.T) {
 	b, ctx := newLocalBackend(t)
 


### PR DESCRIPTION
The t4 driver rejected Watch(revision == compactRevision) with ErrCompacted. 
Per the etcd contract only revisions strictly below the compact revision are unavailable; the compact revision itself must stay watchable. 
