### PR TITLE
rename reserved-word aliases current/compact for openGauss compatibility

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -33,7 +33,7 @@ var (
 	WithOldVal = WithVal + ", old_value"
 	ListFmt    = `
 		SELECT current_rev, compact_rev, %s
-		FROM (%s) AS kv_current, (%s) AS kv_compact, kine
+		FROM (%s) AS current_rev, (%s) AS compact_rev, kine
 		INNER JOIN (%s) AS mkv USING (id)
 		WHERE (deleted = 0 OR ?)
 		ORDER BY name ASC
@@ -204,14 +204,14 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 
 		GetSingleSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
+			FROM (%s) AS current_rev, (%s) AS compact_rev, kine
 			WHERE id = (%s)
 			AND (deleted = 0 OR ?)`,
 			Columns, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(EqualsNameSQL, "")), paramCharacter, numbered, "GetSingle"),
 
 		GetSingleValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
+			FROM (%s) AS current_rev, (%s) AS compact_rev, kine
 			WHERE id = (%s)
 			AND (deleted = 0 OR ?)`,
 			WithVal, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(EqualsNameSQL, "")), paramCharacter, numbered, "GetSingleVal"),
@@ -232,7 +232,7 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 
 		AfterOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
+			FROM (%s) AS current_rev, (%s) AS compact_rev, kine
 			WHERE	name >= ? AND name < ?
 			AND	id > ?
 			ORDER BY id ASC`,
@@ -240,14 +240,14 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 
 		AfterAllOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
+			FROM (%s) AS current_rev, (%s) AS compact_rev, kine
 			WHERE id > ?
 			ORDER BY id ASC`,
 			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterAllOldVal"),
 
 		AfterSingleOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
+			FROM (%s) AS current_rev, (%s) AS compact_rev, kine
 			WHERE name = ?
 			AND id > ?
 			ORDER BY id ASC`,

--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -33,7 +33,7 @@ var (
 	WithOldVal = WithVal + ", old_value"
 	ListFmt    = `
 		SELECT current_rev, compact_rev, %s
-		FROM (%s) AS current, (%s) AS compact, kine
+		FROM (%s) AS kv_current, (%s) AS kv_compact, kine
 		INNER JOIN (%s) AS mkv USING (id)
 		WHERE (deleted = 0 OR ?)
 		ORDER BY name ASC
@@ -204,14 +204,14 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 
 		GetSingleSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS current, (%s) AS compact, kine
+			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
 			WHERE id = (%s)
 			AND (deleted = 0 OR ?)`,
 			Columns, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(EqualsNameSQL, "")), paramCharacter, numbered, "GetSingle"),
 
 		GetSingleValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS current, (%s) AS compact, kine
+			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
 			WHERE id = (%s)
 			AND (deleted = 0 OR ?)`,
 			WithVal, CurrentRevSQL, CompactRevSQL, fmt.Sprintf(EqualsNameSQL, "")), paramCharacter, numbered, "GetSingleVal"),
@@ -232,7 +232,7 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 
 		AfterOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS current, (%s) AS compact, kine
+			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
 			WHERE	name >= ? AND name < ?
 			AND	id > ?
 			ORDER BY id ASC`,
@@ -240,14 +240,14 @@ func OpenDB(ctx context.Context, wg *sync.WaitGroup, driverName string, connecto
 
 		AfterAllOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS current, (%s) AS compact, kine
+			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
 			WHERE id > ?
 			ORDER BY id ASC`,
 			WithOldVal, CurrentRevSQL, CompactRevSQL), paramCharacter, numbered, "AfterAllOldVal"),
 
 		AfterSingleOldValSQL: query.New(fmt.Sprintf(`
 			SELECT current_rev, compact_rev, %s
-			FROM (%s) AS current, (%s) AS compact, kine
+			FROM (%s) AS kv_current, (%s) AS kv_compact, kine
 			WHERE name = ?
 			AND id > ?
 			ORDER BY id ASC`,


### PR DESCRIPTION
## Motivation
openGauss is a PostgreSQL-forked database that speaks the PostgreSQL wire protocol, so it is directly accessible with standard Go PostgreSQL drivers such as pgx. However, two incompatibilities prevent kine from running on it:

* Reserved keyword collision (this PR). openGauss treats COMPACT as a reserved keyword in FROM-clause table aliases, so the startup queries built from ListFmt/After* templates fail with ERROR: syntax error at or near "compact" (SQLSTATE 42601). This makes kine unable to start on openGauss at all.
* Proprietary SHA-256 authentication (deployment prerequisite, no code change needed). Unlike PostgreSQL's standard SCRAM-SHA-256 (RFC 5802), openGauss implements its own SHA-256 challenge-response scheme and reuses the wire-protocol auth code 11 without the preceding SASL negotiation, which standard PG drivers reject (pq: unknown authentication response: 11). For PG-driver compatibility, the openGauss instance must set password_encryption_type = 1 (store both SHA-256 and MD5 hashes) before creating the kine user, so that PG clients can authenticate via the MD5 channel.

## Changes
Rename the subquery aliases current/compact to kv_current/kv_compact (6 occurrences in pkg/drivers/generic/generic.go):

* The new names are dialect-neutral: quoting is not a viable alternative, since double quotes (AS "compact") would break MySQL (parsed as a string literal in the default sql_mode), while backticks would break PostgreSQL/openGauss.
* The aliases are table aliases only — the projected column names (current_rev, compact_rev, ...) and all row.Scan() call sites are untouched, and the aliases are never referenced via qualification elsewhere. The rename is purely semantic-preserving.

## Verification
Full CRUD (create/get/update/list/watch/delete/compact, driven through the etcd v3 gRPC interface) against:

* MySQL 8.0 — PASS
* PostgreSQL 16 — PASS
* openGauss 7.0.0-RC3 (password_encryption_type=1) — PASS, including on a dedicated instance at a remote host

Unpatched v0.16.4 fails to start on openGauss with the syntax error above; MySQL/PostgreSQL behavior is unchanged by this rename.