### PR TITLE
fix(sql): Avoid stalled poll loop in high-write environments

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -18,16 +18,45 @@ import (
 
 const minCompactBatchSize = 100
 
+// maxPollStall is how long the poll loop may go without advancing before compaction stops holding
+// its target back to the poll cursor. Under load the cursor should advance continuously, so this
+// limit wouldn't be hit. When the datastore is idle it sits at the current revision and the limit
+// isn't needed either. If it stops moving for this long the poll loop is assumed to be wedged for
+// some unrelated reason, and compaction is allowed to proceed so that the database does not grow
+// unbounded. The poll loop will then hit a compacted revision and restart the watch stream,
+// matching what happens in the etcd-based code in k8s.io/apiserver.
+const maxPollStall = time.Minute
+
+// maxCompactHold bounds how far compaction may be held back from the revision it would otherwise
+// compact to, while waiting on the poll loop. We need both this and maxPollStall because, under
+// sustained overload the poll cursor keeps advancing, just more slowly than the write head, so the
+// hold would grow without limit and take the size of the database with it. Past this distance the
+// reader is not likely going to catch up, so compaction proceeds anyway and the poll loop takes the
+// same compacted-revision restart it would have taken had we never held it back.
+const maxCompactHold = 10000
+
 type SQLLog struct {
 	sync.RWMutex
 
-	d                     server.Dialect
-	broadcaster           broadcaster.Broadcaster
-	ctx                   context.Context
-	notify                chan int64
-	currentRev            atomic.Int64
-	polledRev             atomic.Int64
-	polled                *sync.Cond
+	d           server.Dialect
+	broadcaster broadcaster.Broadcaster
+	ctx         context.Context
+	notify      chan int64
+	currentRev  atomic.Int64
+	polledRev   atomic.Int64
+	polled      *sync.Cond
+
+	// polling is true while the poll loop is running; polledAt records the last time polledRev
+	// actually advanced. Compaction consults both so that it does not delete rows the poll loop has
+	// not read yet. See compact().
+	polling  atomic.Bool
+	polledAt atomic.Int64
+
+	// compactorOnce guards the compactor goroutine. The poll loop can now exit
+	// and be restarted by the broadcaster, which calls startWatch again; without
+	// this we would leak an additional compactor on every restart.
+	compactorOnce sync.Once
+
 	compactInterval       time.Duration
 	compactIntervalJitter int
 	compactTimeout        time.Duration
@@ -256,6 +285,21 @@ func (s *SQLLog) compact(compactRev int64, targetCompactRev int64) (int64, int64
 	// Ensure that we never compact the most recent 1000 revisions
 	targetCompactRev = safeCompactRev(targetCompactRev, currentRev, s.compactMinRetain)
 
+	// Never compact past the poll loop's position while it is making progress. The poll loop is not
+	// a client watcher that can be told to resync. It is this process' _only_ reader of the log,
+	// and every watch is fed from it. Deleting rows it has not read yet leaves a permanent hole
+	// that cannot be filled, causing a hang. See the actual poll() loop for why this is a problem
+	// and how it is handled.
+	if s.polling.Load() && time.Since(time.Unix(0, s.polledAt.Load())) < maxPollStall {
+		if polledRev := s.polledRev.Load(); polledRev > 0 && targetCompactRev > polledRev {
+			// Hold back to the poll cursor, but never by more than maxCompactHold.
+			if heldRev := max(polledRev, targetCompactRev-maxCompactHold); heldRev < targetCompactRev {
+				logrus.Debugf("COMPACT holding target revision %d back to %d for poll cursor %d", targetCompactRev, heldRev, polledRev)
+				targetCompactRev = heldRev
+			}
+		}
+	}
+
 	// Don't bother compacting to a revision that has already been compacted
 	if targetCompactRev <= compactRev {
 		logrus.Tracef("COMPACT revision %d has already been compacted", targetCompactRev)
@@ -462,12 +506,15 @@ func (s *SQLLog) startWatch() (chan server.Events, error) {
 	maxJitter := float64(s.compactIntervalJitter) / 100.0 * float64(s.compactInterval)
 	jitter := time.Duration(rand.Float64()*2*maxJitter - maxJitter)
 
-	// start compaction and polling at the same time to watch starts
-	// at the oldest revision, but compaction doesn't create gaps
+	// The compactor is started only once for the lifetime of the SQLLog. The poll loop may exit and
+	// be restarted (see poll()), which brings us back through startWatch, and a second compactor
+	// would double-compact.
 	if s.compactInterval <= 0 {
 		logrus.Debugf("COMPACT disabled; automatic compaction will not occur")
 	} else {
-		go s.compactor(s.compactInterval + jitter)
+		s.compactorOnce.Do(func() {
+			go s.compactor(s.compactInterval + jitter)
+		})
 	}
 
 	go s.poll(c, pollStart)
@@ -480,12 +527,19 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 		skipTime     time.Time
 		waitForMore  = true
 		pollRevision = pollStart
+		lastPolled   = pollStart
 		trace        = logrus.IsLevelEnabled(logrus.TraceLevel)
 	)
 
 	wait := time.NewTicker(time.Second)
 	defer wait.Stop()
 	defer close(result)
+
+	// This is where we mark that the poll loop is running and record the last time it advanced. The
+	// compactor consults both of these to avoid deleting rows that the poll loop has not yet read.
+	s.polling.Store(true)
+	s.polledAt.Store(time.Now().UnixNano())
+	defer s.polling.Store(false)
 
 	for {
 		if waitForMore {
@@ -503,6 +557,10 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 
 		//  update polled revision to reflect what rows have already been seen
 		s.Lock()
+		if pollRevision != lastPolled {
+			lastPolled = pollRevision
+			s.polledAt.Store(time.Now().UnixNano())
+		}
 		s.polledRev.Store(pollRevision)
 		s.polled.Broadcast()
 		s.Unlock()
@@ -515,7 +573,7 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			continue
 		}
 
-		_, _, events, err := RowsToEvents(rows, true, true)
+		_, compactRev, events, err := RowsToEvents(rows, true, true)
 		if err != nil {
 			logrus.Errorf("fail to convert rows changes: %v", err)
 			continue
@@ -544,6 +602,25 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			if event.KV.ModRevision != next {
 				if trace {
 					logrus.Tracef("MODREVISION GAP: expected %v, got %v", next, event.KV.ModRevision)
+				}
+				// NOTE: If the missing revision is at or below the compact revision then its row
+				// has been deleted and is never coming back. Filling the gap would advance the poll
+				// cursor past a revision whose event was never broadcast, silently desyncing every
+				// watcher. The major problem with this is that filling only advances the cursor one
+				// revision per round trip (at least in the one implementation of the Dialect
+				// interface). So in a busy system with lots of writers, this unintentionally
+				// throttles this loop to a crawl by doing one insert at a time, which writes can
+				// easily outpace. Essentially this leads to all watchers returning nothing (and any
+				// new watchers also not working because it is all fed from this same poll)
+				//
+				// So we do what etcd does when a watcher falls behind the compact revision: kill
+				// the poll by returning, which closes the broadcast, which cancels every watcher.
+				// Clients re-establish, and Watch() returns ErrCompacted with the compact revision
+				// for any client that is now below it, so the apiserver relists. A fresh poll loop
+				// then starts at the current revision.
+				if compactRev > 0 && next <= compactRev {
+					logrus.Errorf("POLL revision %d has been compacted (compact revision %d); restarting watch stream so clients resync", next, compactRev)
+					return
 				}
 				if canSkipRevision(next, skip, skipTime) {
 					// This situation should never happen, but we have it here as a fallback just for unknown reasons


### PR DESCRIPTION
**UPDATE**: While the high write speed I initially found below does trigger the issue, it probably isn't what people are actually running into. The real issue with my production was gaps introduced due to conflicted writes and `SERIAL` types in Postgres causing gaps. I've updated the reproduction in the repo linked below

This is an attempt to solve a bug I found running k3s in a production environment with high writes.

I wrote up a longer form description of the issue, along with instructions on how to reproduce the issue here: https://github.com/thomastaylor312/kine-repro. This is taken directly from the README there so it is available in the issue too:

## What it looks like

This was hard to diagnose because almost everything still works. But this seemed to be the pattern:

- `apiserver_watch_cache_events_received_total` goes flat for **every** resource, on **every** replica, at roughly the same time.
- Writes keep committing at full rate.
- `kubectl get` still returns current data, because a quorum read goes straight to the datastore and never touches the watch cache.
- Controllers and operators quietly stop reacting to anything. Their informers are alive, connected, and receiving nothing.
- It never recovers on its own. Restarting the process fixes it instantly and completely.

## What I think is happening

TL;DR: kine's compactor deletes rows that its own poll loop has not read yet, and the repair path for the resulting hole is much slower than normal operation, so it can never catch back up.

The longer version, in order:

1. `poll()` in `pkg/logstructured/sqllog/sql.go` is a single goroutine that queries all keys and is the only source of watch events for every prefix on the process. There is one cursor, and everything downstream is fed from it.
2. Under sustained write load that cursor falls behind the write revision. Under normal operation it catches up in batches of `pollBatchSize` (500–1000).
3. The compactor is driven entirely by the write revision. `safeCompactRev` compares against `currentRev`, and `polledRev` is referenced in exactly three places in the whole codebase: where it's declared, where `poll()` writes it, and where `WaitForSyncTo` reads it. Nothing in the compaction path ever looks at it. So compaction happily deletes rows the poll loop has not consumed.
4. Now `poll()` queries for `pollRevision+1` and gets back a row with a higher `ModRevision`. It sees a hole. That hole is permanent, because the row it's waiting for was deleted.
5. The gap branch calls `Fill()`, which inserts a `gap-<rev>` marker row and advances the cursor by _exactly one revision_ before starting on the next loop
6. So the poll loop is now repairing at one revision per query-plus-insert round trip instead of draining hundreds per query. I measured roughly 27 revisions/second in my production workload.

Once the repair rate drops below the write rate (which was around 60-70/s in my production workload), the gap diverges and the poll loop never emits another real event. For all intents and purposes, every watch on that process is dead.

There is a `canSkipRevision` that will give up on a hole after one second and skip forward, logging a `GAP` error. But it only fires when `Fill` keeps *failing*. On the success path, filling advances the cursor by one, which changes the revision being waited on, which resets the tracking. So the one-second timer never expires. You end up with zero `GAP` lines. 

> [!NOTE]
> - I completely understand that this is fairly stable code and is considered mostly correct. I found the other issues that touched this area already, so maybe what is going on is already the right answer and this fix is not the right way to solve it. Either way, I thought this would be useful
> - I have no problems if this is completely thrown away, I just thought the problem would be easier to show via code + my repro repository. I can also close this PR and open as just an issue
> - I also know #746 is in progress, but as far as I could tell, it doesn't address this issue
> - AI helped me write the repro, but I have read through every line and basically re-wrote the readme.