### PR TITLE
Fix retry backoff factor being ~1ms instead of 100ms

### DIFF
--- a/pkg/drivers/generic/generic.go
+++ b/pkg/drivers/generic/generic.go
@@ -314,7 +314,7 @@ func (d *Generic) execute(ctx context.Context, sql *query.Named, args ...any) (r
 		metrics.ObserveSQL(startTime, d.ErrCode(err), retries, query)
 	}()
 
-	wait := strategy.Backoff(backoff.Linear(100 + time.Millisecond))
+	wait := strategy.Backoff(backoff.Linear(100 * time.Millisecond))
 	for ; retries < 20; retries++ {
 		logrus.Tracef("EXEC (try=%d): %s", retries, query)
 		result, err = d.DB.ExecContext(ctx, sql.Query, args...)
@@ -509,7 +509,7 @@ func (d *Generic) Insert(ctx context.Context, key string, create, delete bool, c
 	// visible until the transaction completes, at which point we may have already created a gap fill record.
 	// Retry the insert if the driver indicates a retriable insert error, to avoid presenting a spurious
 	// duplicate key error to the client.
-	wait := strategy.Backoff(backoff.Linear(100 + time.Millisecond))
+	wait := strategy.Backoff(backoff.Linear(100 * time.Millisecond))
 	for i := uint(0); i < 20; i++ {
 		row := d.queryRow(ctx, d.InsertSQL, key, cVal, dVal, createRevision, previousRevision, ttl, value, previousRevision)
 		err = row.Scan(&id)


### PR DESCRIPTION
## Problem

`pkg/drivers/generic/generic.go:317` and `:512` both read:

```go
wait := strategy.Backoff(backoff.Linear(100 + time.Millisecond))
```

That is `+`, not `*` — 100 **nanoseconds** added to a millisecond, so the backoff factor is 1.0001 ms rather than the intended 100 ms.

`Rican7/retry`'s `backoff.Linear(factor)` returns `factor * attempt`, and `strategy.Backoff` skips the sleep when `attempt == 0`. The 20 attempts therefore sleep 0, 1, 2 … 19 ms and burn the entire retry budget in **~190 ms** instead of ~19 s.

The live impact is in `Generic.Insert`, which retries serial-id conflicts when the driver reports a retriable insert error — currently only pgsql, via `InsertRetry` (`pkg/drivers/pgsql/pgsql.go:101`). Those retries have been re-hitting the database roughly 100× faster than designed, against a datastore that is by definition already contended at that moment.

## Solution

`100 * time.Millisecond` in both places.

The occurrence in `Generic.execute` is fixed for consistency, but note it is currently unreachable: no driver ever assigns `dialect.Retry`, so `err != nil && d.Retry != nil && d.Retry(err)` is always false and that loop returns on the first iteration. (Worth a separate look — it means SQLite `BUSY` and MySQL deadlocks on compaction DELETEs are not retried at the generic layer at all.)

## Behavior change worth reviewing

With the factor corrected, the worst case is now genuinely ~19 s of cumulative sleep (100 ms × (1+2+…+19)) while holding a pooled connection, where today an insert gives up after ~190 ms. In practice conflicts clear immediately — the first retry does not sleep at all, and the conflict resolves as soon as the in-flight transaction commits — so the tail should be rare. But if 20 attempts at 100 ms linear is more budget than intended, the attempt count is the knob to turn, and I'm happy to lower it in this PR.

## Verification

- `go build ./...`
- `go test -tags=test ./pkg/drivers/...` — passes
- `golangci-lint run pkg/drivers/generic/...` — 0 issues
- Arithmetic confirmed against `Rican7/retry@v0.3.1`: `backoff/backoff.go:26` (`factor * time.Duration(attempt)`) and `strategy/strategy.go:71-77` (no sleep on attempt 0)

## Related, not included here

`pkg/drivers/pgsql/pgsql.go:100` has the same slip in a different form: `dialect.FillRetryDuration = time.Millisecond + 5` adds 5 nanoseconds, and was presumably meant to be `5 * time.Millisecond`. Left out of this PR since it changes gap-fill timing on the watch poll path rather than backoff; happy to fix it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)