### PR TITLE
sqlite: use UNION ALL in the compaction delete set

### DIFF
--- a/pkg/drivers/sqlite/sqlite.go
+++ b/pkg/drivers/sqlite/sqlite.go
@@ -97,7 +97,7 @@ func NewVariant(ctx context.Context, wg *sync.WaitGroup, driverName string, cfg 
 					kp.name != 'compact_rev_key' AND
 					kp.prev_revision != 0 AND
 					kp.id <= ?
-				UNION
+				UNION ALL
 				SELECT kd.id AS id
 				FROM kine AS kd
 				WHERE


### PR DESCRIPTION
## Problem

The two branches of `CompactSQL`'s `IN` subquery are combined with `UNION`, which makes SQLite sort and deduplicate both inputs:

```
QUERY PLAN
`--MERGE (UNION)
   |--LEFT
   |  |--SEARCH kp USING COVERING INDEX kine_id_compact_rev_key_with_prev_revision_index (id<?)
   |  `--USE TEMP B-TREE FOR ORDER BY
   `--RIGHT
      `--SEARCH kd USING COVERING INDEX kine_id_deleted_index (id<?)
```

With `temp_store` at its default of `FILE`, that temp b-tree can spill to the temp directory. And because `compactIter` runs one of these per `--compact-batch-size` revisions inside a `BEGIN IMMEDIATE` transaction, the sort happens while holding the write lock.

The deduplication buys nothing. The result feeds `DELETE FROM kine AS kv WHERE kv.id IN (...)`, where a repeated id is a no-op — the duplicates `UNION` removes are rows that are both deleted and some other row's `prev_revision`, which the DELETE would discard anyway.

## Solution

`UNION` → `UNION ALL`. The plan collapses to two covering index scans with no temp b-tree:

```
QUERY PLAN
`--COMPOUND QUERY
   |--LEFT-MOST SUBQUERY
   |  `--SEARCH kp USING COVERING INDEX kine_id_compact_rev_key_with_prev_revision_index (id<?)
   `--UNION ALL
      `--SEARCH kd USING COVERING INDEX kine_id_deleted_index (id<?)
```

## Measurements

Synthetic table built from this driver's exact schema: 300,000 rows, 20,000 distinct keys, ~6% `deleted != 0`, 800-byte values, 638 MB file. Compacting to revision 250,000, sqlite 3.53.4:

| | delete-set subquery | rows affected by the DELETE |
|---|---|---|
| `UNION` | 0.06 s (3/3 runs) | 231,176 |
| `UNION ALL` | 0.02 s (3/3 runs) | 231,176 |

Run against two copies of the same database, the DELETE leaves **identical** surviving row sets — 68,824 rows with matching id sums. `changes()` is unaffected because the DELETE counts rows deleted, not ids in the subquery, so the `deletedRows` value that `compactIter` logs and acts on does not change.

`go test -tags=test ./pkg/drivers/sqlite/...` passes.

## Scope

SQLite driver only. **Do not apply the same change to the pgsql driver** -- it has a `UNION` in the same position, but there it is load-bearing and removing it is a large regression.

I measured it on PostgreSQL 17.11 with an equivalent 300k-row / 392MB table (230,000 rows with a non-zero `prev_revision`, 17,647 tombstones), compacting to revision 250000, on clones of one template database:

| pgsql `CompactSQL` form | DELETE time | rows affected |
|---|---|---|
| `USING (... UNION ...)` (current) | 1195 / 1299 / 1499 ms | 231176 |
| `USING (... UNION ALL ...)` | 2601 / 3132 ms | 231176 |
| `WHERE id IN (... UNION ...)` | 1981 ms | 231176 |
| `WHERE id IN (... UNION ALL ...)` | 7562 ms | 231176 |

All four delete exactly the same rows. The reason `UNION` wins on Postgres is that the sort/dedup hands the planner a **sorted, unique** stream, so it merge-joins against `kine_pkey`:

```
Delete on kine kv
  ->  Merge Join (actual rows=231176)
        ->  Index Scan using kine_pkey on kine kv (actual rows=249986)
        ->  Unique  ->  Merge Append (actual rows=244705)
Execution Time: 1791 ms
```

With `UNION ALL` the input is unsorted with duplicates, so it switches to a hash join and sequentially scans the entire table to build the hash:

```
Delete on kine kv
  ->  Hash Join (actual rows=244705)
        ->  Append (actual rows=244705)
        ->  Hash (actual rows=300001)
              ->  Seq Scan on kine kv (actual rows=300001)
Execution Time: 5773 ms
```

SQLite's driver uses `WHERE kv.id IN (...)` rather than `USING`, and its planner gets no such benefit from the ordering -- hence the opposite result. The pgsql query is already the best of the forms I measured and should be left as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)