### PR TITLE
sqllog: test poll batch fullness against pollBatchSize

### DIFF
--- a/pkg/logstructured/sqllog/sql.go
+++ b/pkg/logstructured/sqllog/sql.go
@@ -529,7 +529,7 @@ func (s *SQLLog) poll(result chan server.Events, pollStart int64) {
 			continue
 		}
 
-		waitForMore = len(events) < 100
+		waitForMore = int64(len(events)) < s.pollBatchSize
 
 		var (
 			rev        = pollRevision


### PR DESCRIPTION
## Problem

`pkg/logstructured/sqllog/sql.go:532`:

```go
waitForMore = len(events) < 100
```

The poll loop uses this to decide whether to re-query immediately or wait on `notify`/the 1s ticker. But the query it just ran is limited to `s.pollBatchSize` — `--poll-batch-size`, default 500 — and the two values have never been connected. `c7dd89e` ("Select rows to trigger in batches of 500") introduced the literal `100` in the same commit that set the limit to `500`, so this is an original inconsistency rather than drift; the later change that made 500 configurable just widened the gap.

`After()` returns one event per row and stops at the limit, so `len(events) < limit` is exactly the condition "this query drained everything available at that revision". Comparing against any other number makes the test mean something else, in both directions:

- **At the default 500**, a burst of 100-499 events is a fully drained batch that reads as *not full*, so the loop immediately re-issues the same `After ... LIMIT 500` query and finds nothing. One wasted round trip per burst.
- **Below 100**, a *completely full* batch always reads as *not full*, so the loop waits between every batch instead of draining. Clearing a backlog of N revisions takes up to `N / pollBatchSize` **seconds** of watch lag — lowering the knob to reduce per-poll cost silently turns it into a latency cliff.

Every other consumer of the knob is already correct: `app.go` → `endpoint.go` → `drivers/config.go` → each driver's `sqllog.New(...)` → the SQL `LIMIT`. Only this comparison was left on a literal.

## Solution

```go
waitForMore = int64(len(events)) < s.pollBatchSize
```

## Risk

This only affects *when* the loop sleeps, never which events it emits or in what order — the sequential-revision logic below it is untouched.

The one path worth checking is the revision-gap break, which discards the rest of the batch without advancing `pollRevision`. That case is unaffected: it sends `s.notify <- next` with `next > pollRevision`, so the select wakes and re-queries immediately regardless of what `waitForMore` was set to.

At the default of 500 the only behavioral difference is that batches of 100-499 stop triggering a redundant requery; full batches still re-query immediately, exactly as before.

## Verification

`go build ./...` and `go test -tags=test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)